### PR TITLE
Add `Document` types and offline operations

### DIFF
--- a/E3db/Classes/AccessKey.swift
+++ b/E3db/Classes/AccessKey.swift
@@ -49,15 +49,23 @@ public struct EAKInfo {
 
     /// public key of the authorizer
     let authorizerPublicKey: ClientKey
+
+    /// client ID of user performing the signature (typically the writer)
+    let signerId: UUID?
+
+    /// public signing key of the signer
+    let signerSigningKey: SigningKey?
 }
 
 /// :nodoc:
 extension EAKInfo: Argo.Decodable {
     public static func decode(_ j: JSON) -> Decoded<EAKInfo> {
         return curry(EAKInfo.init)
-            <^> j <| "eak"
-            <*> j <| "authorizer_id"
-            <*> j <| "authorizer_public_key"
+            <^> j <|  "eak"
+            <*> j <|  "authorizer_id"
+            <*> j <|  "authorizer_public_key"
+            <*> j <|? "signer_id"
+            <*> j <|? "signer_signing_key"
     }
 }
 
@@ -165,7 +173,7 @@ extension Client {
 
                 // update server
                 self.putAccessKey(eak: eak, writerId: writerId, userId: userId, readerId: readerId, recordType: recordType) { result in
-                    let response  = EAKInfo(eak: eak, authorizerId: self.config.clientId, authorizerPublicKey: client.publicKey)
+                    let response  = EAKInfo(eak: eak, authorizerId: self.config.clientId, authorizerPublicKey: client.publicKey, signerId: self.config.clientId, signerSigningKey:client.signingKey)
                     let accessKey = AccessKey(rawAk: ak, eakInfo: response)
 
                     // update local cache

--- a/E3db/Classes/AccessKey.swift
+++ b/E3db/Classes/AccessKey.swift
@@ -16,13 +16,45 @@ import Runes
 
 // MARK: Access Key Management
 
-struct EAKResponse: Argo.Decodable {
-    let eak: String
-    let authorizerId: UUID
-    let authorizerPublicKey: ClientKey
+class AkCacheKey: NSObject {
+    let writerId: UUID
+    let userId: UUID
+    let recordType: String
 
-    static func decode(_ j: JSON) -> Decoded<EAKResponse> {
-        return curry(EAKResponse.init)
+    init(writerId: UUID, userId: UUID, recordType: String) {
+        self.writerId   = writerId
+        self.userId     = userId
+        self.recordType = recordType
+    }
+}
+
+class AccessKey: NSObject {
+    let rawAk: RawAccessKey
+    let eakInfo: EAKInfo
+
+    init(rawAk: RawAccessKey, eakInfo: EAKInfo) {
+        self.rawAk   = rawAk
+        self.eakInfo = eakInfo
+    }
+}
+
+/// Opaque Encrypted Access Key type to facilitate offline crypto
+public struct EAKInfo {
+
+    /// encrypted key used for encryption operations
+    let eak: String
+
+    /// client ID of user authorizing access (typically the writer)
+    let authorizerId: UUID
+
+    /// public key of the authorizer
+    let authorizerPublicKey: ClientKey
+}
+
+/// :nodoc:
+extension EAKInfo: Argo.Decodable {
+    public static func decode(_ j: JSON) -> Decoded<EAKInfo> {
+        return curry(EAKInfo.init)
             <^> j <| "eak"
             <*> j <| "authorizer_id"
             <*> j <| "authorizer_public_key"
@@ -33,7 +65,7 @@ struct EAKResponse: Argo.Decodable {
 
 extension Client {
     private struct GetEAKRequest: Request {
-        typealias ResponseObject = EAKResponse
+        typealias ResponseObject = EAKInfo
         let api: Api
         let writerId: UUID
         let userId: UUID
@@ -47,38 +79,50 @@ extension Client {
         }
     }
 
-    func decryptEak(eakResponse: EAKResponse, clientPrivateKey: String) -> E3dbResult<AccessKey> {
-        return Result(try Crypto.decrypt(eakResponse: eakResponse, clientPrivateKey: clientPrivateKey))
+    func decryptEak(eakInfo: EAKInfo, clientPrivateKey: String) -> E3dbResult<RawAccessKey> {
+        return Result(try Crypto.decrypt(eakInfo: eakInfo, clientPrivateKey: clientPrivateKey))
     }
 
-    func getAccessKey(writerId: UUID, userId: UUID, readerId: UUID, recordType: String, completion: @escaping E3dbCompletion<AccessKey>) {
+    // checks cache and server for access key, returning error if not found
+    func getStoredAccessKey(writerId: UUID, userId: UUID, readerId: UUID, recordType: String, completion: @escaping E3dbCompletion<AccessKey>) {
         let cacheKey = AkCacheKey(writerId: writerId, userId: userId, recordType: recordType)
 
-        // Check for AK in local cache
-        if let ak = Client.akCache[cacheKey] {
-            return completion(Result(value: ak))
+        // Check for EAKInfo in local cache
+        if let storedAk = akCache.object(forKey: cacheKey) {
+            return completion(Result(value: storedAk))
         }
 
         // Get AK from server
         let req = GetEAKRequest(api: api, writerId: writerId, userId: userId, readerId: readerId, recordType: recordType)
         authedClient.perform(req) { result in
-
             // Server had EAK entry
-            if case .success(let akResponse) = result {
-                let akResult = self.decryptEak(eakResponse: akResponse, clientPrivateKey: self.config.privateKey)
+            switch result {
+            case .success(let eakInfo):
+                let res = self.decryptEak(eakInfo: eakInfo, clientPrivateKey: self.config.privateKey)
+                    .map { AccessKey(rawAk: $0, eakInfo: eakInfo) }
+                completion(res)
+            case .failure(let err):
+                completion(Result(error: E3dbError(swishError: err)))
+            }
+        }
+    }
 
-                // store in cache
-                Client.akCache[cacheKey] = akResult.value
-                return completion(akResult)
+    // checks cache and server for access key, generating one if not found
+    func getAccessKey(writerId: UUID, userId: UUID, readerId: UUID, recordType: String, completion: @escaping E3dbCompletion<AccessKey>) {
+        let cacheKey = AkCacheKey(writerId: writerId, userId: userId, recordType: recordType)
+        getStoredAccessKey(writerId: writerId, userId: userId, readerId: readerId, recordType: recordType) { result in
+            // found access key, return it immediately
+            guard case .failure(let error) = result else {
+                return completion(result)
             }
 
-            // EAK not found on server, generate one
-            guard case .failure(.serverError(404, _)) = result,
+            // access key not found in cache and eak not found on server, generate raw ak
+            guard case .apiError(code: 404, message: _) = error,
                 let ak = Crypto.generateAccessKey() else {
-                return completion(Result(error: .cryptoError("Could not create access key")))
+                    return completion(Result(error: .cryptoError("Could not create access key")))
             }
 
-            // stores AK on server and local cache before returning it to caller
+            // encrypts and stores AK on server and local cache before returning it to caller
             self.putAccessKey(ak: ak, cacheKey: cacheKey, writerId: writerId, userId: userId, readerId: readerId, recordType: recordType, completion: completion)
         }
     }
@@ -109,7 +153,7 @@ extension Client {
         authedClient.performDefault(req, completion: completion)
     }
 
-    func putAccessKey(ak: AccessKey, cacheKey: AkCacheKey, writerId: UUID, userId: UUID, readerId: UUID, recordType: String, completion: @escaping E3dbCompletion<AccessKey>) {
+    func putAccessKey(ak: RawAccessKey, cacheKey: AkCacheKey, writerId: UUID, userId: UUID, readerId: UUID, recordType: String, completion: @escaping E3dbCompletion<AccessKey>) {
         getClientInfo(clientId: readerId) { result in
             switch result {
             case .success(let client):
@@ -121,11 +165,15 @@ extension Client {
 
                 // update server
                 self.putAccessKey(eak: eak, writerId: writerId, userId: userId, readerId: readerId, recordType: recordType) { result in
+                    let response  = EAKInfo(eak: eak, authorizerId: self.config.clientId, authorizerPublicKey: client.publicKey)
+                    let accessKey = AccessKey(rawAk: ak, eakInfo: response)
+
                     // update local cache
                     if case .success = result {
-                        Client.akCache[cacheKey] = ak
+                        self.akCache.setObject(accessKey, forKey: cacheKey)
                     }
-                    completion(result.map { ak })
+
+                    completion(result.map { accessKey })
                 }
             case .failure(let error):
                 completion(Result(error: error))
@@ -157,10 +205,47 @@ extension Client {
     func deleteAccessKey(writerId: UUID, userId: UUID, readerId: UUID, recordType: String, completion: @escaping E3dbCompletion<Void>) {
         // remove from cache
         let cacheKey = AkCacheKey(writerId: writerId, userId: userId, recordType: recordType)
-        Client.akCache[cacheKey] = nil
+        akCache.removeObject(forKey: cacheKey)
 
         // remove from server
         let req = DeleteEAKRequest(api: api, writerId: writerId, userId: userId, readerId: readerId, recordType: recordType)
         authedClient.performDefault(req, completion: completion)
+    }
+}
+
+// MARK: EAK Management
+
+extension Client {
+
+    /// Generate encrypted access key for offline encryption operations. `EAKInfo` objects are
+    /// safe to store in insecure storage as they are encrypted with the current client's private key.
+    /// This method will store the key with E3db for later access.
+    ///
+    /// - SeeAlso: `getReaderKey(writerId:userId:type:completion:)` for geting keys from E3db.
+    ///
+    /// - Parameters:
+    ///   - type: The kind of data that will be encrypted with this key
+    ///   - completion: A handler to call when this operation completes to provide the EAKInfo result
+    public func createWriterKey(type: String, completion: @escaping E3dbCompletion<EAKInfo>) {
+        let id = config.clientId
+        getAccessKey(writerId: id, userId: id, readerId: id, recordType: type) { result in
+            completion(result.map { $0.eakInfo })
+        }
+    }
+
+    /// Get the encrypted access key for offline encryption operations. The EAKInfo object must have
+    /// been created beforehand, and shared with this client.
+    ///
+    /// - SeeAlso: `createWriterKey(type:completion:)` for sending keys to E3db.
+    ///
+    /// - Parameters:
+    ///   - writerId: The client ID of the writer of an encrypted document.
+    ///   - userId: The client ID of the user for which an encrypted document was created.
+    ///   - type: The kind of data that will be encrypted with this key
+    ///   - completion: A handler to call when this operation completes to provide the EAKInfo result, or error if not found.
+    public func getReaderKey(writerId: UUID, userId: UUID, type: String, completion: @escaping E3dbCompletion<EAKInfo>) {
+        getStoredAccessKey(writerId: writerId, userId: userId, readerId: config.clientId, recordType: type) { result in
+            completion(result.map { $0.eakInfo })
+        }
     }
 }

--- a/E3db/Classes/Client.swift
+++ b/E3db/Classes/Client.swift
@@ -96,6 +96,19 @@ extension Client {
         return KeyPair(publicKey: pubKey, secretKey: privKey)
     }
 
+    /// A helper function to create a compatible key pair for E3db signature operations.
+    ///
+    /// - Note: This method is not required for library use. A key pair is
+    ///   generated and stored in the `Config` object returned by the
+    ///   `Client.register(token:clientName:apiUrl:completion:)` method.
+    ///
+    /// - Returns: A key pair containing Base64URL encoded Ed25519 public and private keys.
+    public static func generateSigningKeyPair() -> KeyPair? {
+        guard let keyPair = Crypto.generateSigningKeyPair() else { return nil }
+        let pubKey  = keyPair.publicKey.base64URLEncodedString()
+        let privKey = keyPair.secretKey.base64URLEncodedString()
+        return KeyPair(publicKey: pubKey, secretKey: privKey)
+    }
 }
 
 // MARK: Get Client Info

--- a/E3db/Classes/Client.swift
+++ b/E3db/Classes/Client.swift
@@ -19,7 +19,7 @@ import ResponseDetective
 #endif
 
 /// A type that contains either a value of type `T` or an `E3dbError`
-public typealias E3dbResult<T>     = Result<T, E3dbError>
+public typealias E3dbResult<T> = Result<T, E3dbError>
 
 /// A completion handler that operates on an `E3dbResult<T>` type,
 /// used for async callbacks for E3db `Client` methods.
@@ -116,13 +116,15 @@ extension Client {
 struct ClientInfo: Argo.Decodable {
     let clientId: UUID
     let publicKey: ClientKey
+    let signingKey: SigningKey?
     let validated: Bool
 
     static func decode(_ j: JSON) -> Decoded<ClientInfo> {
         return curry(ClientInfo.init)
-            <^> j <| "client_id"
-            <*> j <| "public_key"
-            <*> j <| "validated"
+            <^> j <|  "client_id"
+            <*> j <|  "public_key"
+            <*> j <|? "signing_key"
+            <*> j <|  "validated"
     }
 }
 

--- a/E3db/Classes/Config.swift
+++ b/E3db/Classes/Config.swift
@@ -25,14 +25,20 @@ public struct Config {
     /// The API secret for making authenticated calls
     public let apiSecret: String
 
-    /// The client's public key
+    /// The client's public encryption key
     public let publicKey: String
 
-    /// The client's secret key
+    /// The client's secret encryption key
     public let privateKey: String
 
     /// The base URL for the E3DB service
     public let baseApiUrl: URL
+
+    /// The client's public signing key
+    public let publicSigKey: String
+
+    /// The client's secret signing key
+    public let privateSigKey: String
 
     /// Initializer to customize the configuration of the client. Typically, library users will
     /// use the `Client.register(token:clientName:apiUrl:completion:)` method which will supply
@@ -55,7 +61,11 @@ public struct Config {
         apiSecret: String,
         publicKey: String,
         privateKey: String,
-        baseApiUrl: URL
+        baseApiUrl: URL,
+        // TODO: remove blank defaults when
+        // service is updated to support signing keys
+        publicSigKey: String = "",
+        privateSigKey: String = ""
     ) {
         self.clientName = clientName
         self.clientId = clientId
@@ -64,6 +74,8 @@ public struct Config {
         self.publicKey = publicKey
         self.privateKey = privateKey
         self.baseApiUrl = baseApiUrl
+        self.publicSigKey = publicSigKey
+        self.privateSigKey = privateSigKey
     }
 }
 
@@ -80,7 +92,9 @@ extension Config: Ogra.Encodable, Argo.Decodable {
             "api_secret": apiSecret.encode(),
             "public_key": publicKey.encode(),
             "private_key": privateKey.encode(),
-            "base_api_url": baseApiUrl.encode()
+            "base_api_url": baseApiUrl.encode(),
+            "public_sig_key": publicSigKey.encode(),
+            "private_sig_key": privateSigKey.encode()
         ])
     }
 
@@ -95,6 +109,8 @@ extension Config: Ogra.Encodable, Argo.Decodable {
             <*> j <| "public_key"
             <*> j <| "private_key"
             <*> j <| "base_api_url"
+            <*> j <| "public_sig_key"
+            <*> j <| "private_sig_key"
     }
 }
 

--- a/E3db/Classes/Config.swift
+++ b/E3db/Classes/Config.swift
@@ -62,10 +62,8 @@ public struct Config {
         publicKey: String,
         privateKey: String,
         baseApiUrl: URL,
-        // TODO: remove blank defaults when
-        // service is updated to support signing keys
-        publicSigKey: String = "",
-        privateSigKey: String = ""
+        publicSigKey: String,
+        privateSigKey: String
     ) {
         self.clientName = clientName
         self.clientId = clientId

--- a/E3db/Classes/Crypto.swift
+++ b/E3db/Classes/Crypto.swift
@@ -6,7 +6,7 @@
 import Foundation
 import Sodium
 
-typealias AccessKey          = Box.SecretKey
+typealias RawAccessKey       = SecretBox.Key
 typealias EncryptedAccessKey = String
 
 struct Crypto {
@@ -22,8 +22,12 @@ extension Crypto {
         return sodium.box.keyPair()
     }
 
-    static func generateAccessKey() -> AccessKey? {
-        return sodium.randomBytes.buf(length: sodium.box.SecretKeyBytes)
+    static func generateSigningKeyPair() -> Sign.KeyPair? {
+        return sodium.sign.keyPair()
+    }
+
+    static func generateAccessKey() -> RawAccessKey? {
+        return sodium.secretBox.key()
     }
 
     static func b64Join(_ ciphertexts: Data...) -> String {
@@ -51,18 +55,18 @@ extension Crypto {
 
 extension Crypto {
 
-    static func encrypt(accessKey: AccessKey, readerClientKey: ClientKey, authorizerPrivKey: Box.SecretKey) -> EncryptedAccessKey? {
+    static func encrypt(accessKey: RawAccessKey, readerClientKey: ClientKey, authorizerPrivKey: Box.SecretKey) -> EncryptedAccessKey? {
         return Box.PublicKey(base64URLEncoded: readerClientKey.curve25519)
             .flatMap { sodium.box.seal(message: accessKey, recipientPublicKey: $0, senderSecretKey: authorizerPrivKey) }
             .map { (eakData: BoxCipherNonce) in b64Join(eakData.authenticatedCipherText, eakData.nonce) }
     }
 
-    static func decrypt(eakResponse: EAKResponse, clientPrivateKey: String) throws -> AccessKey {
-        guard let (eak, eakN) = b64SplitEak(eakResponse.eak) else {
+    static func decrypt(eakInfo: EAKInfo, clientPrivateKey: String) throws -> RawAccessKey {
+        guard let (eak, eakN) = b64SplitEak(eakInfo.eak) else {
             throw E3dbError.cryptoError("Invalid access key format")
         }
 
-        guard let authorizerPubKey = Box.PublicKey(base64URLEncoded: eakResponse.authorizerPublicKey.curve25519),
+        guard let authorizerPubKey = Box.PublicKey(base64URLEncoded: eakInfo.authorizerPublicKey.curve25519),
               let privKey = Box.SecretKey(base64URLEncoded: clientPrivateKey),
               let ak = sodium.box.open(authenticatedCipherText: eak, senderPublicKey: authorizerPubKey, recipientSecretKey: privKey, nonce: eakN) else {
             throw E3dbError.cryptoError("Failed to decrypt access key")
@@ -76,9 +80,9 @@ extension Crypto {
 
 extension Crypto {
 
-    private static func generateSecretKey() throws -> SecretBox.Key {
+    private static func generateDataKey() throws -> SecretBox.Key {
         guard let secretKey = sodium.secretBox.key() else {
-            throw E3dbError.cryptoError("Failed to generate secret box key.")
+            throw E3dbError.cryptoError("Failed to generate data key.")
         }
         return secretKey
     }
@@ -91,12 +95,12 @@ extension Crypto {
         return cipher
     }
 
-    static func encrypt(recordData: RecordData, ak: AccessKey) throws -> CipherData {
+    static func encrypt(recordData: RecordData, ak: RawAccessKey) throws -> CipherData {
         var encrypted = CipherData()
 
         for (key, value) in recordData.cleartext {
             let bytes       = value.data(using: .utf8)
-            let dk          = try generateSecretKey()
+            let dk          = try generateDataKey()
             let (ef, efN)   = try encrypt(value: bytes, key: dk)
             let (edk, edkN) = try encrypt(value: dk, key: ak)
             encrypted[key]  = b64Join(edk, edkN, ef, efN)
@@ -111,7 +115,7 @@ extension Crypto {
         return plain
     }
 
-    static func decrypt(cipherData: CipherData, ak: AccessKey) throws -> RecordData {
+    static func decrypt(cipherData: CipherData, ak: RawAccessKey) throws -> RecordData {
         var decrypted = Cleartext()
 
         for (key, value) in cipherData {

--- a/E3db/Classes/Crypto.swift
+++ b/E3db/Classes/Crypto.swift
@@ -82,7 +82,7 @@ extension Crypto {
 
     private static func generateDataKey() throws -> SecretBox.Key {
         guard let secretKey = sodium.secretBox.key() else {
-            throw E3dbError.cryptoError("Failed to generate data key.")
+            throw E3dbError.cryptoError("Failed to generate data key")
         }
         return secretKey
     }
@@ -90,7 +90,7 @@ extension Crypto {
     private static func encrypt(value: Data?, key: SecretBox.Key) throws -> SecretBoxCipherNonce {
         guard let data = value,
               let cipher: SecretBoxCipherNonce = sodium.secretBox.seal(message: data, secretKey: key) else {
-            throw E3dbError.cryptoError("Failed to encrypt value.")
+            throw E3dbError.cryptoError("Failed to encrypt value")
         }
         return cipher
     }
@@ -110,7 +110,7 @@ extension Crypto {
 
     private static func decrypt(ciphertext: Data, nonce: SecretBox.Nonce, key: SecretBox.Key) throws -> Data {
         guard let plain = sodium.secretBox.open(authenticatedCipherText: ciphertext, secretKey: key, nonce: nonce) else {
-            throw E3dbError.cryptoError("Failed to decrypt value.")
+            throw E3dbError.cryptoError("Failed to decrypt value")
         }
         return plain
     }

--- a/E3db/Classes/Crypto.swift
+++ b/E3db/Classes/Crypto.swift
@@ -129,3 +129,20 @@ extension Crypto {
         return RecordData(cleartext: decrypted)
     }
 }
+
+// MARK: Document Crypto
+
+extension Crypto {
+
+    static func signature(doc: Signable, signingKey: Sign.SecretKey) -> String? {
+        let message = Data(doc.serialized().utf8)
+        return sodium.sign.signature(message: message, secretKey: signingKey)?.base64URLEncodedString()
+    }
+
+    static func verify(doc: Signable, encodedSig: String, verifyingKey: Sign.PublicKey) -> Bool? {
+        let message = Data(doc.serialized().utf8)
+        return Data(base64URLEncoded: encodedSig)
+            .map { sodium.sign.verify(message: message, publicKey: verifyingKey, signature: $0) }
+    }
+
+}

--- a/E3db/Classes/Document.swift
+++ b/E3db/Classes/Document.swift
@@ -14,33 +14,75 @@ import Sodium
 
 // MARK: Offline Crypto Operations
 
+/// Protocol to allow types to be cryptographically
+/// signed and verified. Requires serialization to
+/// be deterministic.
 public protocol Signable {
-    // must be deterministic
+
+    /// Provides a reproducible string representation
+    /// of the data to sign and verify. Requires the
+    /// serialization to be deterministic -- i.e. types
+    /// such as `Dictionary` and `Set` must be serialized
+    /// in a reproducible order.
+    ///
+    /// - Returns: Reproducible string representation of the type
     func serialized() -> String
 }
 
+/// Data type to hold encrypted data and related info
 public struct EncryptedDocument: Signable {
+
+    /// Metadata produced by this client about this document
     public let clientMeta: ClientMeta
+
+    /// The ciphertext after it has been encrypted,
+    /// the keys remain unencrypted
     public let encryptedData: CipherData
+
+    /// A cryptographic signature of the `clientMeta`
+    /// and the cleartext data before it was encrypted
     public let recordSignature: String
 }
 
+/// Data type to hold the unencrypted data and related info
 public struct DecryptedDocument {
+
+    /// Metadata produced by this client about this document
     public let clientMeta: ClientMeta
+
+    /// The plaintext information where both keys and values
+    /// are unencrypted
     public let data: Cleartext
+
+    /// Whether this document's data and cleartext matched the signature
+    /// provided when verified against a given signing public key
     public let verified: Bool
 }
 
+/// A wrapper object around a given data type and its
+/// cryptographic signature. Note that document remains unchanged
 public struct SignedDocument<T: Signable>: Signable {
+
+    /// A data type that conforms to the `Signable` protocol
+    /// (i.e. it is deterministically serializable)
     public let document: T
+
+    /// The cryptographic signature over the serialized document
     public let signature: String
 
+    /// Initializer to manually create `SignedDocument` types.
+    ///
+    /// - Parameters:
+    ///   - document: A data type that conforms to the `Signable` protocol
+    ///   - signature: The cryptographic signature over the serialized document
     public init(document: T, signature: String) {
         self.document  = document
         self.signature = signature
     }
 }
 
+// allows anything that conforms to the JSON Encodable
+// protocol to also be Signable
 extension Signable where Self: Ogra.Encodable {
     public func serialized() -> String {
         return encode().serialize()
@@ -75,7 +117,7 @@ extension String: Signable {
 }
 
 extension Client {
-    private struct RecordInfo: Signable {
+    private struct DocInfo: Signable {
         let meta: ClientMeta
         let data: RecordData
 
@@ -93,6 +135,14 @@ extension Client {
         return localAk
     }
 
+    /// Use the client's private signing key to create a cryptographic signature
+    /// over the serialized representation of the given document.
+    ///
+    /// - Note: this does not change the document at all (e.g. the values are _not_ encrypted).
+    ///
+    /// - Parameter document: A data type that conforms to the `Signable` protocol
+    /// - Returns: A wrapper object around a given data type and its cryptographic signature
+    /// - Throws: `E3dbError.cryptoError` if the operation failed
     public func sign<T: Signable>(document: T) throws -> SignedDocument<T> {
         guard let privSigKey = Sign.SecretKey(base64URLEncoded: config.privateSigKey),
               let signature  = Crypto.signature(doc: document, signingKey: privSigKey) else {
@@ -101,6 +151,14 @@ extension Client {
         return SignedDocument(document: document, signature: signature)
     }
 
+    /// Verify message authenticity. Confirm that the signature for the `SignedDocument` was
+    /// created by the client identified by the given public key, for the document provided.
+    ///
+    /// - Parameters:
+    ///   - signed: A wrapper object around a given data type and its cryptographic signature
+    ///   - pubSigKey: The public portion of the key used to create the signature in the `signed` document
+    /// - Returns: Whether the document was signed by the creator of the given public key
+    /// - Throws: `E3dbError.cryptoError` if the operation failed
     public func verify<T>(signed: SignedDocument<T>, pubSigKey: String) throws -> Bool {
         guard let pubSigKey    = Sign.PublicKey(base64URLEncoded: pubSigKey),
               let verification = Crypto.verify(doc: signed.document, encodedSig: signed.signature, verifyingKey: pubSigKey) else {
@@ -109,21 +167,43 @@ extension Client {
         return verification
     }
 
+    /// Create a document to hold data signed for authenticity and encrypted for confidentiality.
+    /// The resulting document also holds info related to the author, type of data, and any additional
+    /// metadata kept in cleartext.
+    ///
+    /// - Parameters:
+    ///   - type: The kind of data this document represents
+    ///   - data: The cleartext data to be encrypted
+    ///   - eakInfo: The encrypted access key information used for the encryption operation
+    ///   - plain: Additional metadata to be included -- remains unencrypted.
+    /// - Returns: Data type to hold encrypted data and related info
+    /// - Throws: `E3dbError.cryptoError` if the operation failed
     public func encrypt(type: String, data: RecordData, eakInfo: EAKInfo, plain: PlainMeta? = nil) throws -> EncryptedDocument {
         let clientId  = config.clientId
         let meta      = ClientMeta(writerId: clientId, userId: clientId, type: type, plain: plain)
-        let recInfo   = RecordInfo(meta: meta, data: data)
+        let recInfo   = DocInfo(meta: meta, data: data)
         let localAk   = try getLocalAk(clientId: clientId, recordType: type, eakInfo: eakInfo)
         let signed    = try sign(document: recInfo)
         let encrypted = try Crypto.encrypt(recordData: recInfo.data, ak: localAk)
         return EncryptedDocument(clientMeta: meta, encryptedData: encrypted, recordSignature: signed.signature)
     }
 
+    /// Create a document to hold the original plaintext data from the given encrypted format.
+    /// The resulting document also holds info related to the author, type of data, and any additional
+    /// metadata kept in cleartext. The input document is also verified for authenticity with the given
+    /// public signing key.
+    ///
+    /// - Parameters:
+    ///   - encryptedDoc: Data type to hold encrypted data and related info
+    ///   - eakInfo: The encrypted access key information used for the decryption operation
+    ///   - writerPubSigKey: The public portion of the key used to create the signature for the `encryptedDoc`
+    /// - Returns: Data type to hold the unencrypted data and related info
+    /// - Throws: `E3dbError.cryptoError` if the operation failed
     public func decrypt(encryptedDoc: EncryptedDocument, eakInfo: EAKInfo, writerPubSigKey: String) throws -> DecryptedDocument {
         let meta      = encryptedDoc.clientMeta
         let localAk   = try getLocalAk(clientId: eakInfo.authorizerId, recordType: meta.type, eakInfo: eakInfo)
         let decrypted = try Crypto.decrypt(cipherData: encryptedDoc.encryptedData, ak: localAk)
-        let recInfo   = RecordInfo(meta: meta, data: decrypted)
+        let recInfo   = DocInfo(meta: meta, data: decrypted)
         let signed    = SignedDocument(document: recInfo, signature: encryptedDoc.recordSignature)
         let verified  = try verify(signed: signed, pubSigKey: writerPubSigKey)
         return DecryptedDocument(clientMeta: meta, data: decrypted.cleartext, verified: verified)

--- a/E3db/Classes/Document.swift
+++ b/E3db/Classes/Document.swift
@@ -1,0 +1,132 @@
+//
+//  Document.swift
+//  E3db
+//
+
+import Foundation
+import Swish
+import Argo
+import Ogra
+import Curry
+import Runes
+import Result
+import Sodium
+
+// MARK: Offline Crypto Operations
+
+public protocol Signable {
+    // must be deterministic
+    func serialized() -> String
+}
+
+public struct EncryptedDocument: Signable {
+    public let clientMeta: ClientMeta
+    public let encryptedData: CipherData
+    public let recordSignature: String
+}
+
+public struct DecryptedDocument {
+    public let clientMeta: ClientMeta
+    public let data: Cleartext
+    public let verified: Bool
+}
+
+public struct SignedDocument<T: Signable>: Signable {
+    public let document: T
+    public let signature: String
+
+    public init(document: T, signature: String) {
+        self.document  = document
+        self.signature = signature
+    }
+}
+
+extension Signable where Self: Ogra.Encodable {
+    public func serialized() -> String {
+        return encode().serialize()
+    }
+}
+
+extension EncryptedDocument: Ogra.Encodable {
+    public func encode() -> JSON {
+        return JSON.object([
+            "meta": clientMeta.encode(),
+            "data": encryptedData.encode(),
+            "rec_sig": recordSignature.encode()
+        ])
+    }
+}
+
+extension SignedDocument: Ogra.Encodable {
+    public func encode() -> JSON {
+        let encoded = document.serialized()
+        let jsonObj = try? JSONSerialization.jsonObject(with: Data(encoded.utf8), options: [])
+        return JSON.object([
+            "doc": JSON(jsonObj ?? encoded),
+            "sig": signature.encode()
+        ])
+    }
+}
+
+extension String: Signable {
+    public func serialized() -> String {
+        return self
+    }
+}
+
+extension Client {
+    private struct RecordInfo: Signable {
+        let meta: ClientMeta
+        let data: RecordData
+
+        func serialized() -> String {
+            return meta.serialized() + data.serialized()
+        }
+    }
+
+    // Check for AK in local cache or decrypt the given EAK
+    private func getLocalAk(clientId: UUID, recordType: String, eakInfo: EAKInfo) throws -> RawAccessKey {
+        let cacheKey = AkCacheKey(writerId: clientId, userId: clientId, recordType: recordType)
+        guard let localAk = akCache.object(forKey: cacheKey)?.rawAk ?? (try? Crypto.decrypt(eakInfo: eakInfo, clientPrivateKey: config.privateKey)) else {
+            throw E3dbError.cryptoError("Failed to decrypt access key")
+        }
+        return localAk
+    }
+
+    public func sign<T: Signable>(document: T) throws -> SignedDocument<T> {
+        guard let privSigKey = Sign.SecretKey(base64URLEncoded: config.privateSigKey),
+              let signature  = Crypto.signature(doc: document, signingKey: privSigKey) else {
+            throw E3dbError.cryptoError("Failed to sign document")
+        }
+        return SignedDocument(document: document, signature: signature)
+    }
+
+    public func verify<T>(signed: SignedDocument<T>, pubSigKey: String) throws -> Bool {
+        guard let pubSigKey    = Sign.PublicKey(base64URLEncoded: pubSigKey),
+              let verification = Crypto.verify(doc: signed.document, encodedSig: signed.signature, verifyingKey: pubSigKey) else {
+            throw E3dbError.cryptoError("Failed to verify document")
+        }
+        return verification
+    }
+
+    public func encrypt(type: String, data: RecordData, eakInfo: EAKInfo, plain: PlainMeta? = nil) throws -> EncryptedDocument {
+        let clientId  = config.clientId
+        let meta      = ClientMeta(writerId: clientId, userId: clientId, type: type, plain: plain)
+        let recInfo   = RecordInfo(meta: meta, data: data)
+        let localAk   = try getLocalAk(clientId: clientId, recordType: type, eakInfo: eakInfo)
+        let signed    = try sign(document: recInfo)
+        let encrypted = try Crypto.encrypt(recordData: recInfo.data, ak: localAk)
+        return EncryptedDocument(clientMeta: meta, encryptedData: encrypted, recordSignature: signed.signature)
+    }
+
+    public func decrypt(encryptedDoc: EncryptedDocument, eakInfo: EAKInfo, writerPubSigKey: String) throws -> DecryptedDocument {
+        let meta      = encryptedDoc.clientMeta
+        let localAk   = try getLocalAk(clientId: eakInfo.authorizerId, recordType: meta.type, eakInfo: eakInfo)
+        let decrypted = try Crypto.decrypt(cipherData: encryptedDoc.encryptedData, ak: localAk)
+        let recInfo   = RecordInfo(meta: meta, data: decrypted)
+        let signed    = SignedDocument(document: recInfo, signature: encryptedDoc.recordSignature)
+        let verified  = try verify(signed: signed, pubSigKey: writerPubSigKey)
+        return DecryptedDocument(clientMeta: meta, data: decrypted.cleartext, verified: verified)
+    }
+
+}

--- a/E3db/Classes/Document.swift
+++ b/E3db/Classes/Document.swift
@@ -38,6 +38,10 @@ public struct EncryptedDocument: Signable {
     /// The ciphertext after it has been encrypted,
     /// the keys remain unencrypted
     public let encryptedData: CipherData
+    
+    /// A cryptographic signature of the `clientMeta`
+    /// and the cleartext data before it was encrypted
+    public let recordSignature: String
 }
 
 /// Data type to hold the verified, unencrypted data and related info
@@ -86,7 +90,8 @@ extension EncryptedDocument: Ogra.Encodable {
     public func encode() -> JSON {
         return JSON.object([
             "meta": clientMeta.encode(),
-            "data": encryptedData.encode()
+            "data": encryptedData.encode(),
+            "rec_sig": recordSignature.encode()
         ])
     }
 }
@@ -159,7 +164,7 @@ extension Client {
         return verification
     }
 
-    /// Create a document to hold data encrypted for confidentiality.
+    /// Create a document to hold data signed for authenticicy and encrypted for confidentiality.
     /// The resulting document also holds info related to the author, type of data, and any additional
     /// metadata kept in cleartext.
     ///
@@ -173,24 +178,37 @@ extension Client {
     public func encrypt(type: String, data: RecordData, eakInfo: EAKInfo, plain: PlainMeta? = nil) throws -> EncryptedDocument {
         let clientId  = config.clientId
         let meta      = ClientMeta(writerId: clientId, userId: clientId, type: type, plain: plain)
+        let recInfo   = DocInfo(meta: meta, data: data)
         let localAk   = try getLocalAk(clientId: clientId, recordType: type, eakInfo: eakInfo)
-        let encrypted = try Crypto.encrypt(recordData: data, ak: localAk)
-        return EncryptedDocument(clientMeta: meta, encryptedData: encrypted)
+        let signed    = try sign(document: recInfo)
+        let encrypted = try Crypto.encrypt(recordData: recInfo.data, ak: localAk)
+        return EncryptedDocument(clientMeta: meta, encryptedData: encrypted, recordSignature: signed.signature)
     }
 
     /// Create a document to hold the original plaintext data from the given encrypted format.
     /// The resulting document also holds info related to the author, type of data, and any additional
-    /// metadata kept in cleartext.
+    /// metadata kept in cleartext. The input document is also verified for authenticiy with the given
+    /// public signing key, and throws an error if verification fails.
     ///
     /// - Parameters:
     ///   - encryptedDoc: Data type to hold encrypted data and related info
     ///   - eakInfo: The encrypted access key information used for the decryption operation
     /// - Returns: Data type to hold the unencrypted data and related info
-    /// - Throws: `E3dbError.cryptoError` if the decrypt operation fails
+    /// - Throws: `E3dbError.cryptoError` if the decrypt operation fails, or if the document fails verification
     public func decrypt(encryptedDoc: EncryptedDocument, eakInfo: EAKInfo) throws -> DecryptedDocument {
         let meta      = encryptedDoc.clientMeta
         let localAk   = try getLocalAk(clientId: eakInfo.authorizerId, recordType: meta.type, eakInfo: eakInfo)
         let decrypted = try Crypto.decrypt(cipherData: encryptedDoc.encryptedData, ak: localAk)
+        
+        // attempt to verify if a signing key is present in the EAKInfo instance
+        if let sigKey = eakInfo.signerSigningKey?.ed25519 {
+            let recInfo = DocInfo(meta: meta, data: decrypted)
+            let signed = SignedDocument(document: recInfo, signature: encryptedDoc.recordSignature)
+            guard try verify(signed: signed, pubSigKey: sigKey) else {
+                throw E3dbError.cryptoError("Document failed verification")
+            }
+        }
+        
         return DecryptedDocument(clientMeta: meta, data: decrypted.cleartext)
     }
 

--- a/E3db/Classes/Document.swift
+++ b/E3db/Classes/Document.swift
@@ -196,16 +196,17 @@ extension Client {
     /// - Returns: Data type to hold the unencrypted data and related info
     /// - Throws: `E3dbError.cryptoError` if the decrypt operation fails, or if the document fails verification
     public func decrypt(encryptedDoc: EncryptedDocument, eakInfo: EAKInfo) throws -> DecryptedDocument {
-        guard let sigKey = eakInfo.signerSigningKey?.ed25519 else {
-            throw E3dbError.cryptoError("EAKInfo has no signing key")
-        }
         let meta      = encryptedDoc.clientMeta
         let localAk   = try getLocalAk(clientId: eakInfo.authorizerId, recordType: meta.type, eakInfo: eakInfo)
         let decrypted = try Crypto.decrypt(cipherData: encryptedDoc.encryptedData, ak: localAk)
-        let recInfo   = DocInfo(meta: meta, data: decrypted)
-        let signed    = SignedDocument(document: recInfo, signature: encryptedDoc.recordSignature)
-        guard try verify(signed: signed, pubSigKey: sigKey) else {
-            throw E3dbError.cryptoError("Document failed verification")
+
+        // attempt to verify if a signing key is present in the EAKInfo instance
+        if let sigKey = eakInfo.signerSigningKey?.ed25519 {
+            let recInfo = DocInfo(meta: meta, data: decrypted)
+            let signed  = SignedDocument(document: recInfo, signature: encryptedDoc.recordSignature)
+            guard try verify(signed: signed, pubSigKey: sigKey) else {
+                throw E3dbError.cryptoError("Document failed verification")
+            }
         }
         return DecryptedDocument(clientMeta: meta, data: decrypted.cleartext)
     }

--- a/E3db/Classes/Document.swift
+++ b/E3db/Classes/Document.swift
@@ -108,15 +108,20 @@ extension SignedDocument: Ogra.Encodable {
     }
 }
 
-extension Client {
-    private struct DocInfo: Signable {
-        let meta: ClientMeta
-        let data: RecordData
+// Container for signing and
+// verification operations
+struct DocInfo: Signable {
+    let meta: ClientMeta
+    let data: RecordData
 
-        func serialized() -> String {
-            return meta.serialized() + data.serialized()
-        }
+    // convention for serializing document is
+    // `serialized(ClientMeta) || serialized(CleartextData)`
+    func serialized() -> String {
+        return meta.serialized() + data.serialized()
     }
+}
+
+extension Client {
 
     // Check for AK in local cache or decrypt the given EAK
     private func getLocalAk(clientId: UUID, recordType: String, eakInfo: EAKInfo) throws -> RawAccessKey {

--- a/E3db/Classes/Document.swift
+++ b/E3db/Classes/Document.swift
@@ -89,6 +89,7 @@ extension Signable where Self: Ogra.Encodable {
     }
 }
 
+/// :nodoc:
 extension EncryptedDocument: Ogra.Encodable {
     public func encode() -> JSON {
         return JSON.object([
@@ -99,6 +100,7 @@ extension EncryptedDocument: Ogra.Encodable {
     }
 }
 
+/// :nodoc:
 extension SignedDocument: Ogra.Encodable {
     public func encode() -> JSON {
         let encoded = document.serialized()
@@ -107,12 +109,6 @@ extension SignedDocument: Ogra.Encodable {
             "doc": JSON(jsonObj ?? encoded),
             "sig": signature.encode()
         ])
-    }
-}
-
-extension String: Signable {
-    public func serialized() -> String {
-        return self
     }
 }
 

--- a/E3db/Classes/Extensions/Extensions.swift
+++ b/E3db/Classes/Extensions/Extensions.swift
@@ -36,7 +36,7 @@ extension String {
 
 extension Date: Ogra.Encodable, Argo.Decodable {
     public func encode() -> JSON {
-        return self.iso8601.encode()
+        return iso8601.encode()
     }
 
     public static func decode(_ json: JSON) -> Decoded<Date> {
@@ -50,7 +50,7 @@ extension Date: Ogra.Encodable, Argo.Decodable {
 
 extension URL: Ogra.Encodable, Argo.Decodable {
     public func encode() -> JSON {
-        return self.absoluteString.encode()
+        return absoluteString.encode()
     }
 
     public static func decode(_ json: JSON) -> Decoded<URL> {
@@ -64,7 +64,7 @@ extension URL: Ogra.Encodable, Argo.Decodable {
 
 extension UUID: Ogra.Encodable, Argo.Decodable {
     public func encode() -> JSON {
-        return self.uuidString.lowercased().encode()
+        return uuidString.lowercased().encode()
     }
 
     public static func decode(_ json: JSON) -> Decoded<UUID> {
@@ -95,7 +95,7 @@ extension URL {
 extension Array where Element: ResultProtocol {
     public func sequence<T, E>() -> Result<[T], E> {
         var accum: [T] = []
-        accum.reserveCapacity(self.count)
+        accum.reserveCapacity(count)
 
         for case let result as Result<T, E> in self {
             switch result {
@@ -117,6 +117,7 @@ extension APIClient {
 }
 
 extension JSON: Signable {
+    // swiftlint:disable switch_case_on_newline
     func serialize() -> String {
         switch self {
         case .null:                 return "null"
@@ -139,4 +140,3 @@ extension Dictionary where Key == String, Value == String {
         return JSON.object(mapValues(JSON.string)).serialize()
     }
 }
-

--- a/E3db/Classes/Extensions/Extensions.swift
+++ b/E3db/Classes/Extensions/Extensions.swift
@@ -140,3 +140,9 @@ extension Dictionary where Key == String, Value == String {
         return JSON.object(mapValues(JSON.string)).serialize()
     }
 }
+
+extension String: Signable {
+    public func serialized() -> String {
+        return self
+    }
+}

--- a/E3db/Classes/Query.swift
+++ b/E3db/Classes/Query.swift
@@ -108,7 +108,7 @@ extension QueryParams: Ogra.Encodable {
 struct SearchRecord: Argo.Decodable {
     let meta: Meta
     let data: CipherData?
-    let eakResponse: EAKResponse?
+    let eakInfo: EAKInfo?
 
     static func decode(_ j: JSON) -> Decoded<SearchRecord> {
         return curry(SearchRecord.init)
@@ -163,11 +163,11 @@ extension Client {
 
     private func decryptSearchRecord(_ searchRecord: SearchRecord) -> E3dbResult<Record> {
         guard let cipherData = searchRecord.data,
-              let eakResp    = searchRecord.eakResponse else {
+              let eakInfo    = searchRecord.eakInfo else {
                 return Result(value: Record(meta: searchRecord.meta, data: Cleartext()))
         }
 
-        return decryptEak(eakResponse: eakResp, clientPrivateKey: self.config.privateKey)
+        return decryptEak(eakInfo: eakInfo, clientPrivateKey: self.config.privateKey)
             .flatMap { decrypt(data: cipherData, accessKey: $0) }
             .map { Record(meta: searchRecord.meta, data: $0.cleartext) }
     }

--- a/E3db/Classes/Record.swift
+++ b/E3db/Classes/Record.swift
@@ -18,8 +18,7 @@ public typealias PlainMeta = [String: String]
 public typealias Cleartext = [String: String]
 
 /// The ciphertext from a record after it has been encrypted
-/// :nodoc:
-typealias CipherData       = [String: String]
+public typealias CipherData = [String: String]
 
 /// A wrapper to hold unencrypted values
 public struct RecordData {
@@ -39,20 +38,38 @@ public struct RecordData {
     }
 }
 
-struct MetaRequestInfo: Ogra.Encodable {
-    let writerId: UUID
-    let userId: UUID
-    let type: String
-    let plain: PlainMeta?
-
+/// :nodoc:
+extension RecordData: Ogra.Encodable, Signable {
     public func encode() -> JSON {
-        var encoded = [
+        return JSON.object(cleartext.mapValues(JSON.string))
+    }
+}
+
+/// A type to hold metadata information created by a client
+public struct ClientMeta: Signable {
+    /// An identifier for the writer of the document
+    public let writerId: UUID
+
+    /// An identifier for the user of the document
+    public let userId: UUID
+
+    /// The kind of data this document represents
+    public let type: String
+
+    /// A user-defined, key-value store of metadata
+    /// associated with the document that remains as plaintext
+    public let plain: PlainMeta?
+}
+
+/// :nodoc:
+extension ClientMeta: Ogra.Encodable {
+    public func encode() -> JSON {
+        return JSON.object([
             "writer_id": writerId.encode(),
             "user_id": userId.encode(),
-            "type": type.encode()
-        ]
-        encoded["plain"] = plain?.encode()
-        return JSON.object(encoded)
+            "type": type.encode(),
+            "plain": (plain ?? [:]).encode() // default to empty object
+        ])
     }
 }
 
@@ -108,7 +125,7 @@ extension Meta: Argo.Decodable {
 }
 
 struct RecordRequestInfo: Ogra.Encodable {
-    let meta: MetaRequestInfo
+    let meta: ClientMeta
     let data: CipherData
 
     public func encode() -> JSON {
@@ -155,11 +172,11 @@ extension Client {
         }
     }
 
-    func encrypt(_ data: RecordData, ak: AccessKey) -> E3dbResult<CipherData> {
+    func encrypt(_ data: RecordData, ak: RawAccessKey) -> E3dbResult<CipherData> {
         return Result(try Crypto.encrypt(recordData: data, ak: ak))
     }
 
-    private func write(_ type: String, data: RecordData, plain: PlainMeta?, ak: AccessKey, completion: @escaping E3dbCompletion<Record>) {
+    private func write(_ type: String, data: RecordData, plain: PlainMeta?, ak: RawAccessKey, completion: @escaping E3dbCompletion<Record>) {
 
         let cipher: CipherData
         switch encrypt(data, ak: ak) {
@@ -169,7 +186,7 @@ extension Client {
             return completion(Result(error: err))
         }
 
-        let meta = MetaRequestInfo(
+        let meta = ClientMeta(
             writerId: config.clientId,
             userId: config.clientId,    // for now
             type: type,
@@ -200,7 +217,7 @@ extension Client {
         getAccessKey(writerId: clientId, userId: clientId, readerId: clientId, recordType: type) { result in
             switch result {
             case .success(let ak):
-                self.write(type, data: data, plain: plain, ak: ak, completion: completion)
+                self.write(type, data: data, plain: plain, ak: ak.rawAk, completion: completion)
             case .failure(let err):
                 completion(Result(error: err))
             }
@@ -230,7 +247,7 @@ extension Client {
         }
     }
 
-    func decrypt(data: CipherData, accessKey: AccessKey) -> E3dbResult<RecordData> {
+    func decrypt(data: CipherData, accessKey: RawAccessKey) -> E3dbResult<RecordData> {
         return Result(try Crypto.decrypt(cipherData: data, ak: accessKey))
     }
 
@@ -238,7 +255,7 @@ extension Client {
         let clientId = config.clientId
         getAccessKey(writerId: rec.meta.writerId, userId: rec.meta.userId, readerId: clientId, recordType: rec.meta.type) { akResult in
             let result = akResult
-                .flatMap { self.decrypt(data: rec.cipherData, accessKey: $0) }
+                .flatMap { self.decrypt(data: rec.cipherData, accessKey: $0.rawAk) }
                 .map { Record(meta: rec.meta, data: $0.cleartext) }
             completion(result)
         }
@@ -284,7 +301,7 @@ extension Client {
         }
     }
 
-    private func update(_ recordId: UUID, version: String, metaReq: MetaRequestInfo, data: RecordData, ak: AccessKey, completion: @escaping E3dbCompletion<Record>) {
+    private func update(_ recordId: UUID, version: String, metaReq: ClientMeta, data: RecordData, ak: RawAccessKey, completion: @escaping E3dbCompletion<Record>) {
         let cipher: CipherData
         switch self.encrypt(data, ak: ak) {
         case .success(let c):
@@ -314,13 +331,13 @@ extension Client {
         getAccessKey(writerId: meta.writerId, userId: meta.userId, readerId: config.clientId, recordType: meta.type) { result in
             switch result {
             case .success(let ak):
-                let metaReq = MetaRequestInfo(
+                let metaReq = ClientMeta(
                     writerId: meta.writerId,
                     userId: meta.userId,
                     type: meta.type,
                     plain: plain
                 )
-                self.update(meta.recordId, version: meta.version, metaReq: metaReq, data: newData, ak: ak, completion: completion)
+                self.update(meta.recordId, version: meta.version, metaReq: metaReq, data: newData, ak: ak.rawAk, completion: completion)
             case .failure(let err):
                 completion(Result(error: err))
             }

--- a/E3db/Classes/Register.swift
+++ b/E3db/Classes/Register.swift
@@ -15,11 +15,13 @@ import Sodium
 struct ClientRequest: Ogra.Encodable {
     let name: String
     let publicKey: ClientKey
+    let signingKey: SigningKey
 
     func encode() -> JSON {
         return JSON.object([
             "name": name.encode(),
-            "public_key": publicKey.encode()
+            "public_key": publicKey.encode(),
+            "signing_key": signingKey.encode()
         ])
     }
 }
@@ -36,6 +38,21 @@ struct ClientKey: Ogra.Encodable, Argo.Decodable {
     static func decode(_ j: JSON) -> Decoded<ClientKey> {
         return curry(ClientKey.init)
             <^> j <| "curve25519"
+    }
+}
+
+struct SigningKey: Ogra.Encodable, Argo.Decodable {
+    let ed25519: String
+
+    func encode() -> JSON {
+        return JSON.object([
+            "ed25519": ed25519.encode()
+        ])
+    }
+
+    static func decode(_ j: JSON) -> Decoded<SigningKey> {
+        return curry(SigningKey.init)
+            <^> j <| "ed25519"
     }
 }
 
@@ -57,6 +74,9 @@ public struct ClientCredentials {
     /// The public key registered with the E3db service and used for encryption
     public let publicKey: String
 
+    /// The signing public key registered with the E3db service and used for signature operations
+    public let signingKey: String
+
     /// A flag indicating whether this client is active
     public let enabled: Bool
 }
@@ -70,6 +90,7 @@ extension ClientCredentials: Argo.Decodable {
             <*> j <| "api_secret"
             <*> j <| "name"
             <*> j <| ["public_key", "curve25519"]
+            <*> j <| ["signing_key", "ed25519"]
             <*> j <| "enabled"
     }
 }
@@ -130,7 +151,8 @@ extension Client {
 
         let api       = Api(baseUrl: url)
         let pubKey    = ClientKey(curve25519: keyPair.publicKey)
-        let clientReq = ClientRequest(name: clientName, publicKey: pubKey)
+        let sigKey    = SigningKey(ed25519: signingKeyPair.publicKey)
+        let clientReq = ClientRequest(name: clientName, publicKey: pubKey, signingKey: sigKey)
         let regReq    = RegistrationRequest(api: api, token: token, client: clientReq)
         let performer = NetworkRequestPerformer(session: session)
         let client    = APIClient(requestPerformer: performer)
@@ -167,10 +189,11 @@ extension Client {
     ///   - token: An opaque value associated with an account and generated the InnoVault Console
     ///   - clientName: A name to give this client for registration
     ///   - publicKey: The public key to register with the E3db service and use for encryption operations
+    ///   - signingKey: The public key to register with the E3db service and use for signing operations
     ///   - apiUrl: The base URL for the E3DB service, uses production API URL if none provided here
     ///   - completion: A handler to call when this operation completes to provide `ClientCredentials`
     ///     used to build a `Config` object for initializing an E3db `Client`
-    public static func register(token: String, clientName: String, publicKey: String, apiUrl: String? = nil, completion: @escaping E3dbCompletion<ClientCredentials>) {
+    public static func register(token: String, clientName: String, publicKey: String, signingKey: String, apiUrl: String? = nil, completion: @escaping E3dbCompletion<ClientCredentials>) {
         // ensure api url is valid
         guard let url = URL(string: apiUrl ?? Api.defaultUrl) else {
             return completion(Result(error: .configError("Invalid apiUrl: \(apiUrl ?? "")")))
@@ -178,7 +201,8 @@ extension Client {
 
         let api       = Api(baseUrl: url)
         let pubKey    = ClientKey(curve25519: publicKey)
-        let clientReq = ClientRequest(name: clientName, publicKey: pubKey)
+        let sigKey    = SigningKey(ed25519: signingKey)
+        let clientReq = ClientRequest(name: clientName, publicKey: pubKey, signingKey: sigKey)
         let regReq    = RegistrationRequest(api: api, token: token, client: clientReq)
         let performer = NetworkRequestPerformer(session: session)
         let client    = APIClient(requestPerformer: performer)

--- a/E3db/Classes/Register.swift
+++ b/E3db/Classes/Register.swift
@@ -118,14 +118,14 @@ extension Client {
             return completion(Result(error: .configError("Invalid apiUrl: \(apiUrl ?? "")")))
         }
 
-        // create key pair
+        // create encryption key pair
         guard let keyPair = Client.generateKeyPair() else {
-            return completion(Result(error: .cryptoError("Failed to create key pair.")))
+            return completion(Result(error: .cryptoError("Failed to create encryption key pair")))
         }
 
         // create signing key pair
         guard let signingKeyPair = Client.generateSigningKeyPair() else {
-            return completion(Result(error: .cryptoError("Failed to create signing key pair.")))
+            return completion(Result(error: .cryptoError("Failed to create signing key pair")))
         }
 
         let api       = Api(baseUrl: url)

--- a/E3db/Classes/Register.swift
+++ b/E3db/Classes/Register.swift
@@ -123,6 +123,11 @@ extension Client {
             return completion(Result(error: .cryptoError("Failed to create key pair.")))
         }
 
+        // create signing key pair
+        guard let signingKeyPair = Client.generateSigningKeyPair() else {
+            return completion(Result(error: .cryptoError("Failed to create signing key pair.")))
+        }
+
         let api       = Api(baseUrl: url)
         let pubKey    = ClientKey(curve25519: keyPair.publicKey)
         let clientReq = ClientRequest(name: clientName, publicKey: pubKey)
@@ -140,7 +145,9 @@ extension Client {
                         apiSecret: creds.apiSecret,
                         publicKey: keyPair.publicKey,
                         privateKey: keyPair.secretKey,
-                        baseApiUrl: api.baseUrl
+                        baseApiUrl: api.baseUrl,
+                        publicSigKey: signingKeyPair.publicKey,
+                        privateSigKey: signingKeyPair.secretKey
                     )
                 }
             completion(resp)

--- a/E3db/Classes/Share.swift
+++ b/E3db/Classes/Share.swift
@@ -94,7 +94,7 @@ extension Client {
         }
     }
 
-    private func addSharePolicy(ak: AccessKey, type: String, clientId: UUID, readerId: UUID, completion: @escaping E3dbCompletion<Void>) {
+    private func addSharePolicy(ak: RawAccessKey, type: String, clientId: UUID, readerId: UUID, completion: @escaping E3dbCompletion<Void>) {
         let cacheKey = AkCacheKey(writerId: clientId, userId: clientId, recordType: type)
         putAccessKey(ak: ak, cacheKey: cacheKey, writerId: clientId, userId: clientId, readerId: readerId, recordType: type) { result in
             switch result {
@@ -118,7 +118,7 @@ extension Client {
         getAccessKey(writerId: clientId, userId: clientId, readerId: clientId, recordType: type) { result in
             switch result {
             case .success(let ak):
-                self.addSharePolicy(ak: ak, type: type, clientId: clientId, readerId: readerId, completion: completion)
+                self.addSharePolicy(ak: ak.rawAk, type: type, clientId: clientId, readerId: readerId, completion: completion)
             case .failure:
                 completion(Result(error: .apiError(code: 404, message: "No applicable records exist to share")))
             }

--- a/E3db/Classes/Utils.swift
+++ b/E3db/Classes/Utils.swift
@@ -92,33 +92,9 @@ struct Api {
     }
 }
 
-struct AkCacheKey: Hashable {
-    let writerId: UUID
-    let userId: UUID
-    let recordType: String
-
-    var hashValue: Int {
-        return [writerId, userId]
-            .map { $0.uuidString }
-            .reduce(recordType, +)
-            .hashValue
-    }
-
-    static func == (lhs: AkCacheKey, rhs: AkCacheKey) -> Bool {
-        return lhs.writerId == rhs.writerId &&
-            lhs.userId == rhs.userId &&
-            lhs.recordType == rhs.recordType
-    }
-}
-
 struct AuthedRequestPerformer {
-    let session: URLSession
     let authenticator: Heimdallr
-
-    init(authenticator: Heimdallr, session: URLSession = .shared) {
-        self.session = session
-        self.authenticator = authenticator
-    }
+    let session: URLSession
 }
 
 extension AuthedRequestPerformer: RequestPerformer {

--- a/E3db/Classes/Utils.swift
+++ b/E3db/Classes/Utils.swift
@@ -31,9 +31,9 @@ public enum E3dbError: Swift.Error {
     internal init(swishError: SwishError) {
         switch swishError {
         case let .argoError(.typeMismatch(exp, act)):
-            self = .jsonError(expected: "Expected: \(exp). ", actual: "Actual: \(act).")
+            self = .jsonError(expected: "Expected: \(exp). ", actual: "Actual: \(act)")
         case .argoError(.missingKey(let key)):
-            self = .jsonError(expected: "Expected: \(key). ", actual: "Actual: (key not found).")
+            self = .jsonError(expected: "Expected: \(key). ", actual: "Actual: (key not found)")
         case .argoError(let err):
             self = .jsonError(expected: "", actual: err.description)
         case .serverError(let code, data: _) where code == 401 || code == 403:

--- a/Example/E3db.xcodeproj/project.pbxproj
+++ b/Example/E3db.xcodeproj/project.pbxproj
@@ -10,12 +10,14 @@
 		0DEF64116C09D7CB217CDB1F /* Pods_E3db_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55EFD65963D3932BE626A0EE /* Pods_E3db_Tests.framework */; };
 		2C18845C1F3D0DAA00C8CDC2 /* E3db.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2C1884431F3D0BDA00C8CDC2 /* E3db.framework */; };
 		2C4687BF1F4B58E300B4362B /* E3db.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2C1884431F3D0BDA00C8CDC2 /* E3db.framework */; };
+		2CB7EF9C1FD5B6FB0008D83C /* DocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB7EF961FD5B6D90008D83C /* DocumentTests.swift */; };
+		2CB7EF9D1FD5B6FB0008D83C /* IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB7EF971FD5B6DA0008D83C /* IntegrationTests.swift */; };
+		2CB7EF9E1FD5B6FB0008D83C /* TestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB7EF981FD5B6DA0008D83C /* TestUtils.swift */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACD81AFB9204008FA782 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD71AFB9204008FA782 /* ViewController.swift */; };
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
-		607FACEC1AFB9204008FA782 /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACEB1AFB9204008FA782 /* Tests.swift */; };
 		A2C67530806EF512542BE478 /* Pods_E3db_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 36F59951ED0709118BDE4254 /* Pods_E3db_Example.framework */; };
 /* End PBXBuildFile section */
 
@@ -115,14 +117,14 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = 2C1883271F3D0BDA00C8CDC2 /* Pods.xcodeproj */;
 			proxyType = 1;
-			remoteGlobalIDString = 062F49122969DBC80F5C0601874D8A54;
+			remoteGlobalIDString = 67504C8DF4BF4A64F1CAA2C7FB487B06;
 			remoteInfo = E3db;
 		};
 		2C4687B11F4B58C400B4362B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 2C1883271F3D0BDA00C8CDC2 /* Pods.xcodeproj */;
 			proxyType = 1;
-			remoteGlobalIDString = 062F49122969DBC80F5C0601874D8A54;
+			remoteGlobalIDString = 67504C8DF4BF4A64F1CAA2C7FB487B06;
 			remoteInfo = E3db;
 		};
 		607FACE61AFB9204008FA782 /* PBXContainerItemProxy */ = {
@@ -418,6 +420,9 @@
 		2C18842D1F3D0BDA00C8CDC2 /* VALValet_Protected.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VALValet_Protected.h; sourceTree = "<group>"; };
 		2C18842F1F3D0BDA00C8CDC2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2C1884301F3D0BDA00C8CDC2 /* Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
+		2CB7EF961FD5B6D90008D83C /* DocumentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DocumentTests.swift; sourceTree = "<group>"; };
+		2CB7EF971FD5B6DA0008D83C /* IntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntegrationTests.swift; sourceTree = "<group>"; };
+		2CB7EF981FD5B6DA0008D83C /* TestUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestUtils.swift; sourceTree = "<group>"; };
 		36F59951ED0709118BDE4254 /* Pods_E3db_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_E3db_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4F455C54A50FCC502926EE9B /* Pods-E3db_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-E3db_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-E3db_Example/Pods-E3db_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		55EFD65963D3932BE626A0EE /* Pods_E3db_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_E3db_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -430,7 +435,6 @@
 		607FACDF1AFB9204008FA782 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		607FACE51AFB9204008FA782 /* E3db_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = E3db_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		607FACEB1AFB9204008FA782 /* Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
 		6E610191BA1C8B6D3B859B1B /* E3db.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = E3db.podspec; path = ../E3db.podspec; sourceTree = "<group>"; };
 		73B667B85D4EC4F5EA104FFF /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		9025A04C575EF94CB47E7F0B /* Pods-E3db_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-E3db_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-E3db_Tests/Pods-E3db_Tests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -1281,7 +1285,9 @@
 		607FACE81AFB9204008FA782 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				607FACEB1AFB9204008FA782 /* Tests.swift */,
+				2CB7EF961FD5B6D90008D83C /* DocumentTests.swift */,
+				2CB7EF971FD5B6DA0008D83C /* IntegrationTests.swift */,
+				2CB7EF981FD5B6DA0008D83C /* TestUtils.swift */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
 			);
 			path = Tests;
@@ -1686,7 +1692,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				607FACEC1AFB9204008FA782 /* Tests.swift in Sources */,
+				2CB7EF9D1FD5B6FB0008D83C /* IntegrationTests.swift in Sources */,
+				2CB7EF9E1FD5B6FB0008D83C /* TestUtils.swift in Sources */,
+				2CB7EF9C1FD5B6FB0008D83C /* DocumentTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -19,7 +19,7 @@ PODS:
     - Result (~> 3.0)
   - Ogra (4.1.2):
     - Argo (= 4.1.2)
-  - ResponseDetective (1.2.0)
+  - ResponseDetective (1.2.2)
   - Result (3.2.4)
   - Runes (4.1.0)
   - Sodium (0.5)
@@ -39,10 +39,10 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Argo: 5db06502fc1222d83011f574243089dab25202ff
   Curry: eb3d2c75aec678b3cc7fb2729d2ad6dd121531d1
-  E3db: 4c98a22c2d5846992f4f3a5f81bf9b13409f9168
+  E3db: 13634a1e85136ba9903c552959b05f0edb82243d
   Heimdallr: d2a8b1dc3ecc7ad249c9ffd20c990e2248fcd599
   Ogra: fc959d1038250a83e4ffa11ece1a6bbd3a1e547f
-  ResponseDetective: c05479b4ab72659bdb20d8a6e2c5cd828ac22f26
+  ResponseDetective: 2a1ddb19b895677d418cd1a83c9595a405012b57
   Result: d2d07204ce72856f1fd9130bbe42c35a7b0fea10
   Runes: 72a67a5bbbe1b5fdae08b5a01b10c60d83fc69aa
   Sodium: a3a17f2ba2dc1b83547e13db0075e7c5d426fc55

--- a/Example/Tests/DocumentTests.swift
+++ b/Example/Tests/DocumentTests.swift
@@ -80,7 +80,7 @@ class DocumentTests: XCTestCase, TestUtils {
             let encrypted = try client1!.encrypt(type: type1, data: RecordData(cleartext: testData), eakInfo: eakInfo)
             XCTAssert(encrypted.clientMeta.writerId == config1!.clientId)
 
-            let decrypted = try client1!.decrypt(encryptedDoc: encrypted, eakInfo: eakInfo, writerPubSigKey: config1!.publicSigKey)
+            let decrypted = try client1!.decrypt(encryptedDoc: encrypted, eakInfo: eakInfo)
             XCTAssert(decrypted.clientMeta.writerId == config1!.clientId)
             XCTAssertEqual(decrypted.data, testData)
         } catch {
@@ -115,7 +115,7 @@ class DocumentTests: XCTestCase, TestUtils {
             let encrypted = try client1!.encrypt(type: type1, data: RecordData(cleartext: testData), eakInfo: eakInfo1)
             XCTAssert(encrypted.clientMeta.writerId == config1!.clientId)
 
-            let decrypted = try client2!.decrypt(encryptedDoc: encrypted, eakInfo: eakInfo2!, writerPubSigKey: config1!.publicSigKey)
+            let decrypted = try client2!.decrypt(encryptedDoc: encrypted, eakInfo: eakInfo2!)
             XCTAssert(decrypted.clientMeta.writerId == config1!.clientId)
             XCTAssertEqual(decrypted.data, testData)
         } catch {
@@ -142,27 +142,10 @@ class DocumentTests: XCTestCase, TestUtils {
             XCTAssert(encrypted.clientMeta.writerId == config1!.clientId)
 
             // wrong eakInfo
-            let decrypted = try client1!.decrypt(encryptedDoc: encrypted, eakInfo: eakInfo2, writerPubSigKey: config1!.publicSigKey)
+            let decrypted = try client1!.decrypt(encryptedDoc: encrypted, eakInfo: eakInfo2)
             XCTFail("Decryption should not have succeeded: \(decrypted)")
         } catch E3dbError.cryptoError(let msg) {
             XCTAssert(msg == "Failed to decrypt value")
-        } catch {
-            XCTFail("Threw other error: \(error.localizedDescription)")
-        }
-    }
-
-    func testDecryptVerificationFailure() {
-        let eakInfo = createWriterKey(client: client1!, type: type1)
-        do {
-            let testData = ["test": "data"]
-            let encrypted = try client1!.encrypt(type: type1, data: RecordData(cleartext: testData), eakInfo: eakInfo)
-            XCTAssert(encrypted.clientMeta.writerId == config1!.clientId)
-
-            // wrong public sig key, should decrypt but fail verification step
-            let decrypted = try client1!.decrypt(encryptedDoc: encrypted, eakInfo: eakInfo, writerPubSigKey: config2!.publicSigKey)
-            XCTFail("Verification should not have succeeded: \(decrypted)")
-        } catch E3dbError.cryptoError(let msg) {
-            XCTAssert(msg == "Document failed verification")
         } catch {
             XCTFail("Threw other error: \(error.localizedDescription)")
         }

--- a/Example/Tests/DocumentTests.swift
+++ b/Example/Tests/DocumentTests.swift
@@ -82,7 +82,6 @@ class DocumentTests: XCTestCase, TestUtils {
 
             let decrypted = try client1!.decrypt(encryptedDoc: encrypted, eakInfo: eakInfo, writerPubSigKey: config1!.publicSigKey)
             XCTAssert(decrypted.clientMeta.writerId == config1!.clientId)
-            XCTAssert(decrypted.verified)
             XCTAssertEqual(decrypted.data, testData)
         } catch {
             XCTFail(error.localizedDescription)
@@ -119,7 +118,6 @@ class DocumentTests: XCTestCase, TestUtils {
             let decrypted = try client2!.decrypt(encryptedDoc: encrypted, eakInfo: eakInfo2!, writerPubSigKey: config1!.publicSigKey)
             XCTAssert(decrypted.clientMeta.writerId == config1!.clientId)
             XCTAssertEqual(decrypted.data, testData)
-            XCTAssert(decrypted.verified)
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -147,8 +145,7 @@ class DocumentTests: XCTestCase, TestUtils {
             let decrypted = try client1!.decrypt(encryptedDoc: encrypted, eakInfo: eakInfo2, writerPubSigKey: config1!.publicSigKey)
             XCTFail("Decryption should not have succeeded: \(decrypted)")
         } catch E3dbError.cryptoError(let msg) {
-            print(msg)
-            XCTAssert(msg.count > 0)
+            XCTAssert(msg == "Failed to decrypt value")
         } catch {
             XCTFail("Threw other error: \(error.localizedDescription)")
         }
@@ -163,11 +160,11 @@ class DocumentTests: XCTestCase, TestUtils {
 
             // wrong public sig key, should decrypt but fail verification step
             let decrypted = try client1!.decrypt(encryptedDoc: encrypted, eakInfo: eakInfo, writerPubSigKey: config2!.publicSigKey)
-            XCTAssert(decrypted.clientMeta.writerId == config1!.clientId)
-            XCTAssertEqual(decrypted.data, testData)
-            XCTAssertFalse(decrypted.verified)
+            XCTFail("Verification should not have succeeded: \(decrypted)")
+        } catch E3dbError.cryptoError(let msg) {
+            XCTAssert(msg == "Document failed verification")
         } catch {
-            XCTFail("Threw error: \(error.localizedDescription)")
+            XCTFail("Threw other error: \(error.localizedDescription)")
         }
     }
 

--- a/Example/Tests/DocumentTests.swift
+++ b/Example/Tests/DocumentTests.swift
@@ -1,0 +1,286 @@
+import UIKit
+import XCTest
+
+@testable import E3db
+
+let type1 = "type1"
+let type2 = "type2"
+
+class DocumentTests: XCTestCase, TestUtils {
+
+    var client1: Client?
+    var config1: Config?
+
+    var client2: Client?
+    var config2: Config?
+
+    private func createWriterKey(client: Client, type: String) -> EAKInfo {
+        var eakInfo: EAKInfo?
+        asyncTest("createWriterKey") { (expect) in
+            client.createWriterKey(type: type) { (result) in
+                defer { expect.fulfill() }
+                guard case .success(let eak) = result else {
+                    return XCTFail()
+                }
+                eakInfo = eak
+            }
+        }
+        return eakInfo!
+    }
+
+    override func setUp() {
+        super.setUp()
+
+        let (c1, cfg1) = clientWithConfig()
+        let (c2, cfg2) = clientWithConfig()
+        (client1, config1) = (c1, cfg1)
+        (client2, config2) = (c2, cfg2)
+    }
+
+    func testCanShareEAK() {
+        let test = #function + UUID().uuidString
+        var eakInfo1: EAKInfo?
+
+        asyncTest(test + "createWriterKey") { (expect) in
+            self.client1!.createWriterKey(type: type1) { (result) in
+                defer { expect.fulfill() }
+                guard case .success(let eak1) = result else {
+                    return XCTFail()
+                }
+                eakInfo1 = eak1
+            }
+        }
+        XCTAssertNotNil(eakInfo1)
+
+        asyncTest(test + "share") { (expect) in
+            self.client1!.share(type: type1, readerId: self.config2!.clientId) { (result) in
+                defer { expect.fulfill() }
+                guard case .success = result else {
+                    return XCTFail()
+                }
+            }
+        }
+
+        asyncTest(test + "getReaderKey") { (expect) in
+            self.client1!.getReaderKey(writerId: self.config1!.clientId, userId: self.config1!.clientId, type: type1) { (result) in
+                defer { expect.fulfill() }
+                guard case .success(let eakInfo2) = result else {
+                    return XCTFail()
+                }
+                XCTAssert(eakInfo1!.eak == eakInfo2.eak)
+            }
+        }
+    }
+
+    func testCanEncryptAndDecryptDoc() {
+        let eakInfo = createWriterKey(client: client1!, type: type1)
+
+        do {
+            let testData = ["test": "data"]
+            let encrypted = try client1!.encrypt(type: type1, data: RecordData(cleartext: testData), eakInfo: eakInfo)
+            XCTAssert(encrypted.clientMeta.writerId == config1!.clientId)
+
+            let decrypted = try client1!.decrypt(encryptedDoc: encrypted, eakInfo: eakInfo, writerPubSigKey: config1!.publicSigKey)
+            XCTAssert(decrypted.clientMeta.writerId == config1!.clientId)
+            XCTAssert(decrypted.verified)
+            XCTAssertEqual(decrypted.data, testData)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
+    func testCanEncryptForOtherClient() {
+        let eakInfo1 = createWriterKey(client: client1!, type: type1)
+        var eakInfo2: EAKInfo?
+        asyncTest("share") { (expect) in
+            self.client1!.share(type: type1, readerId: self.config2!.clientId) { (result) in
+                defer { expect.fulfill() }
+                guard case .success = result else {
+                    return XCTFail()
+                }
+            }
+        }
+        asyncTest("getReaderKey") { (expect) in
+            self.client2!.getReaderKey(writerId: self.config1!.clientId, userId: self.config1!.clientId, type: type1) { (result) in
+                defer { expect.fulfill() }
+                guard case .success(let eak2) = result else {
+                    return XCTFail()
+                }
+                eakInfo2 = eak2
+            }
+        }
+        XCTAssertNotNil(eakInfo2)
+
+        do {
+            let testData = ["test": "data"]
+            let encrypted = try client1!.encrypt(type: type1, data: RecordData(cleartext: testData), eakInfo: eakInfo1)
+            XCTAssert(encrypted.clientMeta.writerId == config1!.clientId)
+
+            let decrypted = try client2!.decrypt(encryptedDoc: encrypted, eakInfo: eakInfo2!, writerPubSigKey: config1!.publicSigKey)
+            XCTAssert(decrypted.clientMeta.writerId == config1!.clientId)
+            XCTAssertEqual(decrypted.data, testData)
+            XCTAssert(decrypted.verified)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
+    func testEncryptWithMismatchedEAKInfoFailsWithError() {
+        let eakInfo = createWriterKey(client: client1!, type: type1)
+        XCTAssertThrowsError(try client2!.encrypt(type: type1, data: RecordData(cleartext: ["test": "data"]), eakInfo: eakInfo), "failed to throw error") { (error) in
+            guard case E3dbError.cryptoError(let msg) = error else {
+                return XCTFail("Threw other error: \(error.localizedDescription)")
+            }
+            XCTAssert(msg.count > 0)
+        }
+    }
+
+    func testDecryptFailure() {
+        let eakInfo1 = createWriterKey(client: client1!, type: type1)
+        let eakInfo2 = createWriterKey(client: client1!, type: type2)
+        do {
+            let testData = ["test": "data"]
+            let encrypted = try client1!.encrypt(type: type1, data: RecordData(cleartext: testData), eakInfo: eakInfo1)
+            XCTAssert(encrypted.clientMeta.writerId == config1!.clientId)
+
+            // wrong eakInfo
+            let decrypted = try client1!.decrypt(encryptedDoc: encrypted, eakInfo: eakInfo2, writerPubSigKey: config1!.publicSigKey)
+            XCTFail("Decryption should not have succeeded: \(decrypted)")
+        } catch E3dbError.cryptoError(let msg) {
+            print(msg)
+            XCTAssert(msg.count > 0)
+        } catch {
+            XCTFail("Threw other error: \(error.localizedDescription)")
+        }
+    }
+
+    func testDecryptVerificationFailure() {
+        let eakInfo = createWriterKey(client: client1!, type: type1)
+        do {
+            let testData = ["test": "data"]
+            let encrypted = try client1!.encrypt(type: type1, data: RecordData(cleartext: testData), eakInfo: eakInfo)
+            XCTAssert(encrypted.clientMeta.writerId == config1!.clientId)
+
+            // wrong public sig key, should decrypt but fail verification step
+            let decrypted = try client1!.decrypt(encryptedDoc: encrypted, eakInfo: eakInfo, writerPubSigKey: config2!.publicSigKey)
+            XCTAssert(decrypted.clientMeta.writerId == config1!.clientId)
+            XCTAssertEqual(decrypted.data, testData)
+            XCTAssertFalse(decrypted.verified)
+        } catch {
+            XCTFail("Threw error: \(error.localizedDescription)")
+        }
+    }
+
+    func testCanSignVerifyEncryptedDoc() {
+        let eakInfo = createWriterKey(client: client1!, type: type1)
+        do {
+            let testData = ["test": "data"]
+            let encrypted = try client1!.encrypt(type: type1, data: RecordData(cleartext: testData), eakInfo: eakInfo)
+            XCTAssert(encrypted.clientMeta.writerId == config1!.clientId)
+
+            let signed = try client1!.sign(document: encrypted)
+            XCTAssertEqual(encrypted.encryptedData, signed.document.encryptedData)
+
+            XCTAssert(try client1!.verify(signed: signed, pubSigKey: config1!.publicSigKey))
+        } catch {
+            XCTFail("Threw error: \(error.localizedDescription)")
+        }
+    }
+
+    func testCanSignVerifySignedDoc() {
+        let eakInfo = createWriterKey(client: client1!, type: type1)
+        do {
+            let testData = ["test": "data"]
+            let encrypted = try client1!.encrypt(type: type1, data: RecordData(cleartext: testData), eakInfo: eakInfo)
+            XCTAssert(encrypted.clientMeta.writerId == config1!.clientId)
+
+            // sign once
+            let signed1 = try client1!.sign(document: encrypted)
+            XCTAssertEqual(encrypted.encryptedData, signed1.document.encryptedData)
+
+            // sign again
+            let signed2 = try client1!.sign(document: signed1)
+            XCTAssertEqual(signed1.document.encryptedData, signed2.document.document.encryptedData)
+
+            // create signed doc manually
+            let doc = SignedDocument(document: signed1, signature: signed2.signature)
+
+            // verify outer layer
+            XCTAssert(try client1!.verify(signed: doc, pubSigKey: config1!.publicSigKey))
+        } catch {
+            XCTFail("Threw error: \(error.localizedDescription)")
+        }
+    }
+
+    func testCanSignVerifyCustomSignable() {
+        struct CustomSignableType: Signable {
+            let num: Int
+            let arr: [String]
+
+            func serialized() -> String {
+                return "\(num)" + arr.joined()
+            }
+        }
+        do {
+            let custom = CustomSignableType.init(num: 5, arr: ["test1", "test2", "test3"])
+            let signed = try client1!.sign(document: custom)
+            XCTAssertEqual(custom.arr, signed.document.arr)
+            XCTAssert(try client1!.verify(signed: signed, pubSigKey: config1!.publicSigKey))
+        } catch {
+            XCTFail("Threw error: \(error.localizedDescription)")
+        }
+    }
+
+    func testCanSignAndOtherClientVerify() {
+        let eakInfo = createWriterKey(client: client1!, type: type1)
+        do {
+            let testData = ["test": "data"]
+            let encrypted = try client1!.encrypt(type: type1, data: RecordData(cleartext: testData), eakInfo: eakInfo)
+            XCTAssert(encrypted.clientMeta.writerId == config1!.clientId)
+
+            let signed = try client1!.sign(document: encrypted)
+            XCTAssertEqual(encrypted.encryptedData, signed.document.encryptedData)
+
+            // other client
+            XCTAssert(try client2!.verify(signed: signed, pubSigKey: config1!.publicSigKey))
+        } catch {
+            XCTFail("Threw error: \(error.localizedDescription)")
+        }
+    }
+
+    func testVerificationFailure() {
+        let eakInfo = createWriterKey(client: client1!, type: type1)
+        do {
+            let testData = ["test": "data"]
+            let encrypted = try client1!.encrypt(type: type1, data: RecordData(cleartext: testData), eakInfo: eakInfo)
+            XCTAssert(encrypted.clientMeta.writerId == config1!.clientId)
+
+            let signed = try client1!.sign(document: encrypted)
+            XCTAssertEqual(encrypted.encryptedData, signed.document.encryptedData)
+
+            // modify signature
+            let doc = SignedDocument(document: signed, signature: signed.signature + "bad")
+            XCTAssertThrowsError(try client1!.verify(signed: doc, pubSigKey: config1!.publicSigKey))
+        } catch {
+            XCTFail("Threw other error: \(error.localizedDescription)")
+        }
+    }
+
+    func testVerificationFailureOtherKey() {
+        let eakInfo = createWriterKey(client: client1!, type: type1)
+        do {
+            let testData = ["test": "data"]
+            let encrypted = try client1!.encrypt(type: type1, data: RecordData(cleartext: testData), eakInfo: eakInfo)
+            XCTAssert(encrypted.clientMeta.writerId == config1!.clientId)
+
+            let signed = try client1!.sign(document: encrypted)
+            XCTAssertEqual(encrypted.encryptedData, signed.document.encryptedData)
+
+            // use other client key
+            let verified = try client1!.verify(signed: signed, pubSigKey: config2!.publicSigKey)
+            XCTAssertFalse(verified)
+        } catch {
+            XCTFail("Threw other error: \(error.localizedDescription)")
+        }
+    }
+}

--- a/Example/Tests/IntegrationTests.swift
+++ b/Example/Tests/IntegrationTests.swift
@@ -73,7 +73,6 @@ class IntegrationTests: XCTestCase, TestUtils {
                 let decDoc = try? serverClient.decrypt(encryptedDoc: encDoc!, eakInfo: eakInfo2, writerPubSigKey: config.publicSigKey)
                 XCTAssertNotNil(decDoc)
                 XCTAssertEqual(decDoc!.data, data.cleartext)
-                XCTAssert(decDoc!.verified)
             }
         }
 

--- a/Example/Tests/IntegrationTests.swift
+++ b/Example/Tests/IntegrationTests.swift
@@ -2,14 +2,7 @@ import UIKit
 import XCTest
 import E3db
 
-// non-sensitive test data
-// for running integration tests
-struct TestData {
-    static let apiUrl = ""
-    static let token  = ""
-}
-
-class IntegrationTests: XCTestCase {
+class IntegrationTests: XCTestCase, TestUtils {
 
     func testIntermediaryUseCase() {
         let (e3db, config) = clientWithConfig()
@@ -55,8 +48,6 @@ class IntegrationTests: XCTestCase {
 
         let signed = try? e3db.sign(document: encDoc!)
         XCTAssertNotNil(signed)
-
-        print("signed: \(signed!.serialized())")
 
         // emulates intermediary operations
 
@@ -658,70 +649,6 @@ class IntegrationTests: XCTestCase {
                 XCTAssertNil(result.error)
                 expect.fulfill()
             }
-        }
-    }
-}
-
-extension IntegrationTests {
-
-    func asyncTest(_ testName: String, test: @escaping (XCTestExpectation) -> Void) {
-        test(expectation(description: testName))
-        waitForExpectations(timeout: 10, handler: { XCTAssertNil($0) })
-    }
-
-    func clientWithConfig() -> (Client, Config) {
-        var e3db: Client?
-        var conf: Config?
-        let newClient = #function + UUID().uuidString
-        asyncTest(newClient) { (expect) in
-            Client.register(token: TestData.token, clientName: newClient, apiUrl: TestData.apiUrl) { (result) in
-                XCTAssertNotNil(result.value)
-                conf = result.value
-                e3db = Client(config: conf!)
-                expect.fulfill()
-            }
-        }
-        return (e3db!, conf!)
-    }
-
-    func clientWithId() -> (Client, UUID) {
-        let (e3db, conf) = clientWithConfig()
-        return (e3db, conf.clientId)
-    }
-
-    func client() -> Client {
-        let (e3db, _) = clientWithConfig()
-        return e3db
-    }
-
-    func writeTestRecord(_ e3db: Client, _ contentType: String = "test-data") -> Record {
-        var record: Record?
-        asyncTest(#function + "write") { (expect) in
-            e3db.write(type: contentType, data: RecordData(cleartext: ["test": "message"])) { (result) in
-                record = result.value!
-                expect.fulfill()
-            }
-        }
-        return record!
-    }
-
-    func deleteRecord(_ record: Record, e3db: Client) {
-        asyncTest(#function + "delete") { (expect) in
-            e3db.delete(recordId: record.meta.recordId, version: record.meta.version) { _ in expect.fulfill() }
-        }
-    }
-
-    func deleteAllRecords(_ e3db: Client) {
-        let test = #function + "delete all"
-        var records = [Record]()
-        asyncTest(test) { (expect) in
-            e3db.query(params: QueryParams()) { (result) in
-                records = result.value!.records
-                expect.fulfill()
-            }
-        }
-        records.forEach { (record) in
-            deleteRecord(record, e3db: e3db)
         }
     }
 }

--- a/Example/Tests/TestUtils.swift
+++ b/Example/Tests/TestUtils.swift
@@ -1,0 +1,84 @@
+import UIKit
+import XCTest
+import E3db
+
+// non-sensitive test data
+// for running integration tests
+struct TestData {
+    static let apiUrl = ""
+    static let token  = ""
+}
+
+protocol TestUtils {
+    func asyncTest(_ testName: String, test: @escaping (XCTestExpectation) -> Void)
+    func clientWithConfig() -> (Client, Config)
+    func clientWithId() -> (Client, UUID)
+    func client() -> Client
+    func writeTestRecord(_ e3db: Client, _ contentType: String) -> Record
+    func deleteRecord(_ record: Record, e3db: Client)
+    func deleteAllRecords(_ e3db: Client)
+}
+
+extension TestUtils where Self: XCTestCase {
+
+    func asyncTest(_ testName: String, test: @escaping (XCTestExpectation) -> Void) {
+        test(expectation(description: testName))
+        waitForExpectations(timeout: 10, handler: { XCTAssertNil($0) })
+    }
+
+    func clientWithConfig() -> (Client, Config) {
+        var e3db: Client?
+        var conf: Config?
+        let newClient = #function + UUID().uuidString
+        asyncTest(newClient) { (expect) in
+            Client.register(token: TestData.token, clientName: newClient, apiUrl: TestData.apiUrl) { (result) in
+                XCTAssertNotNil(result.value)
+                conf = result.value
+                e3db = Client(config: conf!)
+                expect.fulfill()
+            }
+        }
+        return (e3db!, conf!)
+    }
+
+    func clientWithId() -> (Client, UUID) {
+        let (e3db, conf) = clientWithConfig()
+        return (e3db, conf.clientId)
+    }
+
+    func client() -> Client {
+        let (e3db, _) = clientWithConfig()
+        return e3db
+    }
+
+    func writeTestRecord(_ e3db: Client, _ contentType: String = "test-data") -> Record {
+        var record: Record?
+        asyncTest(#function + "write") { (expect) in
+            e3db.write(type: contentType, data: RecordData(cleartext: ["test": "message"])) { (result) in
+                record = result.value!
+                expect.fulfill()
+            }
+        }
+        return record!
+    }
+
+    func deleteRecord(_ record: Record, e3db: Client) {
+        asyncTest(#function + "delete") { (expect) in
+            e3db.delete(recordId: record.meta.recordId, version: record.meta.version) { _ in expect.fulfill() }
+        }
+    }
+
+    func deleteAllRecords(_ e3db: Client) {
+        let test = #function + "delete all"
+        var records = [Record]()
+        asyncTest(test) { (expect) in
+            e3db.query(params: QueryParams()) { (result) in
+                records = result.value!.records
+                expect.fulfill()
+            }
+        }
+        records.forEach { (record) in
+            deleteRecord(record, e3db: e3db)
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -300,8 +300,8 @@ confident in:
   * Proof-of-authorship - The author of the document held the private signing
     key associated with the given public key when the document was created.
 
-To create a signature, use the `sign` method (assumes an encrypted document as
-shown above):
+To create a signature, use the `sign` method. (This example assumes an encrypted
+document as shown above):
 
 ```swift
 let encrypted = // get encrypted document (e.g. read from local storage)
@@ -315,7 +315,7 @@ instance as above. `config` holds the private & public keys for the client.
 that wrote the record):
 
 ```swift
-guard try! e3db?.verify(signed: signed, pubSigKey: config1!.publicSigKey)) else {
+guard try! e3db?.verify(signed: signed, pubSigKey: config!.publicSigKey)) else {
     return print("Document failed verification")
 }
 // Document verified!


### PR DESCRIPTION
`Document` types and operations help facilitate offline crypto.

- Expose opaque `EAKInfo` type
- `createWriterKey` and `getReaderKey` are networked ops to manage EAKs
- Offline `sign` and `verify` operations for generic input
- Offline `encrypt` and `decrypt` operations produce record-compatible documents (includes `ClientMeta`)
- Adds tests including proof-of-concept use-case.