### PR TITLE
Make EAKInfo and internals conform to Codable

### DIFF
--- a/E3db/Classes/AccessKey.swift
+++ b/E3db/Classes/AccessKey.swift
@@ -38,23 +38,23 @@ class AccessKey: NSObject {
     }
 }
 
-/// Opaque Encrypted Access Key type to facilitate offline crypto
-public struct EAKInfo {
+/// Encrypted Access Key information type to facilitate offline crypto
+public struct EAKInfo: Swift.Codable {
 
     /// encrypted key used for encryption operations
-    let eak: String
+    public let eak: String
 
     /// client ID of user authorizing access (typically the writer)
-    let authorizerId: UUID
+    public let authorizerId: UUID
 
     /// public key of the authorizer
-    let authorizerPublicKey: ClientKey
+    public let authorizerPublicKey: ClientKey
 
     /// client ID of user performing the signature (typically the writer)
-    let signerId: UUID?
+    public let signerId: UUID?
 
     /// public signing key of the signer
-    let signerSigningKey: SigningKey?
+    public let signerSigningKey: SigningKey?
 }
 
 /// :nodoc:

--- a/E3db/Classes/Register.swift
+++ b/E3db/Classes/Register.swift
@@ -26,31 +26,43 @@ struct ClientRequest: Ogra.Encodable {
     }
 }
 
-struct ClientKey: Ogra.Encodable, Argo.Decodable {
-    let curve25519: String
+/// A type that holds a public encryption key
+public struct ClientKey: Swift.Codable {
 
-    func encode() -> JSON {
+    /// The Base64URL encoded value for the public encryption key
+    let curve25519: String
+}
+
+/// :nodoc:
+extension ClientKey: Ogra.Encodable, Argo.Decodable {
+    public func encode() -> JSON {
         return JSON.object([
             "curve25519": curve25519.encode()
         ])
     }
 
-    static func decode(_ j: JSON) -> Decoded<ClientKey> {
+    static public func decode(_ j: JSON) -> Decoded<ClientKey> {
         return curry(ClientKey.init)
             <^> j <| "curve25519"
     }
 }
 
-struct SigningKey: Ogra.Encodable, Argo.Decodable {
-    let ed25519: String
+/// A type that holds a public signing key
+public struct SigningKey: Swift.Codable {
 
-    func encode() -> JSON {
+    /// The Base64URL encoded value for the public signing key
+    let ed25519: String
+}
+
+/// :nodoc:
+extension SigningKey: Ogra.Encodable, Argo.Decodable {
+    public func encode() -> JSON {
         return JSON.object([
             "ed25519": ed25519.encode()
         ])
     }
 
-    static func decode(_ j: JSON) -> Decoded<SigningKey> {
+    static public func decode(_ j: JSON) -> Decoded<SigningKey> {
         return curry(SigningKey.init)
             <^> j <| "ed25519"
     }

--- a/Example/Tests/DocumentTests.swift
+++ b/Example/Tests/DocumentTests.swift
@@ -37,6 +37,32 @@ class DocumentTests: XCTestCase, TestUtils {
         (client2, config2) = (c2, cfg2)
     }
 
+    func testCanStoreAndRetrieveEAKInfo() {
+        let eakInfo = createWriterKey(client: client1!, type: type1)
+
+        do {
+            // serialize
+            let serialized = try JSONEncoder().encode(eakInfo)
+
+            // store and retrieve in user defaults
+            let defaultsKey = "eak"
+            let defaults    = UserDefaults.standard
+
+            defaults.set(serialized, forKey: defaultsKey)
+            guard let retrieved = (defaults.value(forKey: defaultsKey) as? Data) else {
+                return XCTFail("Could not retrieve eak data from defaults")
+            }
+
+            // deserialize into eak
+            let deserialized = try JSONDecoder().decode(EAKInfo.self, from: retrieved)
+
+            // compare that they are the same
+            XCTAssertEqual(eakInfo, deserialized)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
     func testCanShareEAK() {
         let test = #function + UUID().uuidString
         var eakInfo1: EAKInfo?

--- a/Example/Tests/TestUtils.swift
+++ b/Example/Tests/TestUtils.swift
@@ -124,6 +124,13 @@ extension TestUtils where Self: XCTestCase {
     }
 }
 
+// allows quick comparisons for testing
+extension EAKInfo: Equatable {
+    public static func ==(lhs: EAKInfo, rhs: EAKInfo) -> Bool {
+        return lhs.eak == rhs.eak
+    }
+}
+
 // MARK: - Collect the memory sizes from different types
 
 protocol MemoryReportable {


### PR DESCRIPTION
- This allows easy serialization for storing the eak to disk
  via Swift's `Encodable` and `Decodable` protocols
- Chose to expose the internal members as public to match Java a bit
- Users cannot create `EAKInfo` structs directly, but they can `getReaderKey`
  or use some decoder, e.g.
```swift
// assuming eakData was stored with JSONEncoder()
let eakFromDisk = try JSONDecoder().decode(EAKInfo.self, eakData)
```