### PR TITLE
Support for files

### DIFF
--- a/E3db/Classes/Client.swift
+++ b/E3db/Classes/Client.swift
@@ -20,12 +20,14 @@ public typealias E3dbCompletion<T> = (E3dbResult<T>) -> Void
 public final class Client {
     let api: Api
     let config: Config
+    let session: URLSession
     let authedClient: APIClient
     let akCache = NSCache<AkCacheKey, AccessKey>()
 
     init(config: Config, urlSession: URLSession, scheduler: @escaping Scheduler) {
-        self.api    = Api(baseUrl: config.baseApiUrl)
-        self.config = config
+        self.api     = Api(baseUrl: config.baseApiUrl)
+        self.config  = config
+        self.session = urlSession
 
         let httpClient    = HeimdallrHTTPClientURLSession(urlSession: urlSession)
         let credentials   = OAuthClientCredentials(id: config.apiKeyId, secret: config.apiSecret)

--- a/E3db/Classes/Crypto.swift
+++ b/E3db/Classes/Crypto.swift
@@ -205,7 +205,7 @@ extension Crypto {
 
         var buffer = input.readData(ofLength: blockSize)
         while !buffer.isEmpty {
-            _ = buffer.withUnsafeBytes { CC_MD5_Update(context, $0, CC_LONG(buffer.count)) }
+            buffer.updateMD5(context: context)
             buffer = input.readData(ofLength: blockSize)
         }
         var digest = [UInt8](repeating: 0, count: Int(CC_MD5_DIGEST_LENGTH))
@@ -244,8 +244,8 @@ extension Crypto {
         let streamHeader = stream.header()
         output.write(headerData)
         output.write(streamHeader)
-        _ = headerData.withUnsafeBytes { CC_MD5_Update(context, $0, CC_LONG(headerData.count)) }
-        _ = streamHeader.withUnsafeBytes { CC_MD5_Update(context, $0, CC_LONG(streamHeader.count)) }
+        headerData.updateMD5(context: context)
+        streamHeader.updateMD5(context: context)
 
         // simulate 2-element queue for easy EOF detection
         var headBuf = input.readData(ofLength: blockSize)
@@ -257,7 +257,7 @@ extension Crypto {
                 throw E3dbError.cryptoError("Failed to encrypted data")
             }
             output.write(cipherText)
-            _ = cipherText.withUnsafeBytes { CC_MD5_Update(context, $0, CC_LONG(cipherText.count)) }
+            cipherText.updateMD5(context: context)
 
             size   += UInt64(cipherText.count)
             headBuf = nextBuf

--- a/E3db/Classes/Crypto.swift
+++ b/E3db/Classes/Crypto.swift
@@ -3,7 +3,9 @@
 //  E3db
 //
 
+#if canImport(CommonCrypto)
 import CommonCrypto
+#endif
 import Foundation
 import Sodium
 
@@ -190,6 +192,9 @@ extension Crypto {
     }
 
     static func md5(of file: URL) throws -> String {
+        #if !canImport(CommonCrypto)
+            throw E3dbError.cryptoError("Cannot perform MD5 without CommonCrypto module.")
+        #endif
         let input   = try FileHandle(forReadingFrom: file)
         let context = UnsafeMutablePointer<CC_MD5_CTX>.allocate(capacity: 1)
         defer {
@@ -208,7 +213,12 @@ extension Crypto {
         return Data(digest).base64EncodedString()
     }
 
+    // swiftlint:disable function_body_length
     static func encrypt(fileAt src: URL, ak: RawAccessKey) throws -> EncryptedFileInfo {
+        #if !canImport(CommonCrypto)
+            throw E3dbError.cryptoError("Cannot perform file encryption without CommonCrypto module.")
+        #endif
+
         guard let dk = sodium.secretStream.xchacha20poly1305.key(),
               let stream = sodium.secretStream.xchacha20poly1305.initPush(secretKey: dk) else {
             throw E3dbError.cryptoError("Failed to initialize stream")
@@ -264,6 +274,10 @@ extension Crypto {
     }
 
     static func decrypt(fileAt src: URL, to dst: URL, ak: RawAccessKey) throws {
+        #if !canImport(CommonCrypto)
+            throw E3dbError.cryptoError("Cannot perform file decryption without CommonCrypto module.")
+        #endif
+
         let input  = try FileHandle(forReadingFrom: src)
         let output = try FileHandle(forWritingTo: dst)
 

--- a/E3db/Classes/Document.swift
+++ b/E3db/Classes/Document.swift
@@ -167,7 +167,7 @@ extension Client {
     /// - Throws: `E3dbError.cryptoError` if the operation failed
     public func encrypt(type: String, data: RecordData, eakInfo: EAKInfo, plain: PlainMeta? = nil) throws -> EncryptedDocument {
         let clientId  = config.clientId
-        let meta      = ClientMeta(writerId: clientId, userId: clientId, type: type, plain: plain)
+        let meta      = ClientMeta(writerId: clientId, userId: clientId, type: type, plain: plain, fileMeta: nil)
         let docInfo   = DocInfo(meta: meta, data: data)
         let signed    = try sign(document: docInfo)
         let localAk   = try getLocalAk(clientId: clientId, recordType: type, eakInfo: eakInfo)

--- a/E3db/Classes/Extensions.swift
+++ b/E3db/Classes/Extensions.swift
@@ -3,6 +3,9 @@
 //  E3db
 //
 
+#if canImport(CommonCrypto)
+import CommonCrypto
+#endif
 import Foundation
 import Result
 import Swish
@@ -130,6 +133,7 @@ extension APIClient {
 }
 
 extension Data {
+
     public init?(base64UrlEncoded string: String) {
         guard let data = try? Crypto.base64UrlDecoded(string: string) else {
             return nil
@@ -140,6 +144,12 @@ extension Data {
     public func base64UrlEncodedString() -> String? {
         return try? Crypto.base64UrlEncoded(data: self)
     }
+
+    #if canImport(CommonCrypto)
+    func updateMD5(context: UnsafeMutablePointer<CC_MD5_CTX>) {
+        _ = withUnsafeBytes { CC_MD5_Update(context, $0, CC_LONG(count)) }
+    }
+    #endif
 }
 
 extension FileManager {

--- a/E3db/Classes/File.swift
+++ b/E3db/Classes/File.swift
@@ -21,18 +21,6 @@ public struct FileMeta: Codable {
     }
 }
 
-struct FilePendingUpdate: Decodable {
-    let fileUrl: URL
-    let fileName: String
-    let version: UUID
-
-    enum CodingKeys: String, CodingKey {
-        case fileUrl  = "file_url"
-        case fileName = "file_name"
-        case version
-    }
-}
-
 struct PendingFile: Decodable {
     let fileUrl: URL
     let id: UUID
@@ -118,12 +106,12 @@ extension Client {
                     return completion(result)
                 }
                 let createReq = CreateFileRequest(api: self.api, recordInfo: recInfo)
-                self.authedClient.perform(createReq) { result in
+                self.authedClient.performDefault(createReq) { result in
                     switch result {
                     case .success(let pending):
                         self.upload(file: encrypted, pendingInfo: pending, completion: withCleanup)
                     case .failure(let error):
-                        withCleanup(.failure(E3dbError(swishError: error)))
+                        withCleanup(.failure(error))
                     }
                 }
             } catch {

--- a/E3db/Classes/File.swift
+++ b/E3db/Classes/File.swift
@@ -1,0 +1,155 @@
+//
+//  File.swift
+//  E3db
+//
+
+import Foundation
+
+public struct FileMeta: Codable {
+    let fileUrl: URL?
+    let fileName: String?
+    let checksum: String
+    let compression: String
+    let size: UInt64?
+
+    enum CodingKeys: String, CodingKey {
+        case fileUrl     = "file_url"
+        case fileName    = "file_name"
+        case checksum
+        case compression
+        case size
+    }
+}
+
+struct FilePendingUpdate: Decodable {
+    let fileUrl: URL
+    let fileName: String
+    let version: UUID
+
+    enum CodingKeys: String, CodingKey {
+        case fileUrl  = "file_url"
+        case fileName = "file_name"
+        case version
+    }
+}
+
+struct PendingFile: Decodable {
+    let fileUrl: URL
+    let id: UUID
+
+    enum CodingKeys: String, CodingKey {
+        case fileUrl = "file_url"
+        case id
+    }
+}
+
+extension Client {
+
+    private typealias MetaInfo = (writerId: UUID, userId: UUID, type: String, plain: PlainMeta?)
+
+    private struct CreateFileRequest: E3dbRequest {
+        typealias ResponseObject = PendingFile
+        let api: Api
+
+        let recordInfo: RecordRequestInfo
+        func build() -> URLRequest {
+            let url = api.url(endpoint: .files)
+            var req = URLRequest(url: url)
+            return req.asJsonRequest(.post, payload: recordInfo)
+        }
+    }
+
+    private struct UploadFileRequest: E3dbRequest {
+        typealias ResponseObject = Void
+        let fileUrl: URL
+        let fileMd5: String
+
+        func build() -> URLRequest {
+            var req = URLRequest(url: fileUrl)
+            req.httpMethod = "PUT"
+            req.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
+            req.setValue(fileMd5, forHTTPHeaderField: "Content-MD5")
+            return req
+        }
+    }
+
+    private struct CommitFileRequest: E3dbRequest {
+        typealias ResponseObject = RecordResponse
+        let api: Api
+        let fileId: UUID
+
+        func build() -> URLRequest {
+            let url = api.url(endpoint: .files) / fileId.uuidString
+            var req = URLRequest(url: url)
+            req.httpMethod = "PATCH"
+            return req
+        }
+    }
+
+    public func writeFile(type: String, fileUrl: URL, plain: PlainMeta? = nil, completion: @escaping E3dbCompletion<Meta>) {
+        let clientId = config.clientId
+        getAccessKey(writerId: clientId, userId: clientId, readerId: clientId, recordType: type) { result in
+            switch result {
+            case .success(let accessKey):
+                let info: MetaInfo = (writerId: clientId, userId: clientId, type: type, plain: plain)
+                self.write(file: fileUrl, ak: accessKey.rawAk, info: info, completion: completion)
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+
+    private func write(file: URL, ak: RawAccessKey, info: MetaInfo, completion: @escaping E3dbCompletion<Meta>) {
+        DispatchQueue.global().async {
+            do {
+                // creates a temp encrypted file
+                let encrypted = try Crypto.encrypt(fileAt: file, ak: ak)
+                let fileInfo  = try Crypto.computeInfo(ofFile: encrypted)
+                let fileName  = file.lastPathComponent
+                let fileMeta  = FileMeta(fileUrl: nil, fileName: fileName, checksum: fileInfo.md5, compression: "raw", size: fileInfo.size)
+                let meta      = ClientMeta(writerId: info.writerId, userId: info.userId, type: info.type, plain: info.plain, fileMeta: fileMeta)
+                let recInfo   = RecordRequestInfo(meta: meta, data: [:])
+
+                // remove temp encrypted file when done,
+                // regardless of success or error
+                let withCleanup: E3dbCompletion<Meta> = { result in
+                    _ = try? FileManager.default.removeItem(at: encrypted)
+                    return completion(result)
+                }
+                let createReq = CreateFileRequest(api: self.api, recordInfo: recInfo)
+                self.authedClient.perform(createReq) { result in
+                    switch result {
+                    case .success(let pending):
+                        self.upload(file: encrypted, fileInfo: fileInfo, pendingInfo: pending, completion: withCleanup)
+                    case .failure(let error):
+                        withCleanup(.failure(E3dbError(swishError: error)))
+                    }
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    guard case let err as E3dbError = error else {
+                        return completion(.failure(.cryptoError("Failed to write file")))
+                    }
+                    completion(.failure(err))
+                }
+            }
+        }
+    }
+
+    private func upload(file: URL, fileInfo: FileInfo, pendingInfo: PendingFile, completion: @escaping E3dbCompletion<Meta>) {
+        let uploadReq = UploadFileRequest(fileUrl: pendingInfo.fileUrl, fileMd5: fileInfo.md5)
+        authedClient.upload(fileAt: file, request: uploadReq, session: session) { result in
+            switch result {
+            case .success:
+                self.commit(fileId: pendingInfo.id, completion: completion)
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+
+    private func commit(fileId: UUID, completion: @escaping E3dbCompletion<Meta>) {
+        let commitReq = CommitFileRequest(api: api, fileId: fileId)
+        authedClient.performDefault(commitReq) { resp in completion(resp.map { $0.meta }) }
+    }
+}

--- a/E3db/Classes/File.swift
+++ b/E3db/Classes/File.swift
@@ -5,12 +5,23 @@
 
 import Foundation
 
+/// Represents information about an encrypted file stored by E3DB.
 public struct FileMeta: Codable {
-    let fileUrl: URL?
-    let fileName: String?
-    let checksum: String
-    let compression: String
-    let size: UInt64?
+
+    /// URL where the file can be downloaded
+    public let fileUrl: URL?
+
+    /// Name of the file
+    public let fileName: String?
+
+    /// MD5 checksum for the file, as a Base64 encoded string
+    public let checksum: String
+
+    /// Compression used for the plaintext contents of the file
+    public let compression: String
+
+    /// Size of the encrypted file
+    public let size: UInt64?
 
     enum CodingKeys: String, CodingKey {
         case fileUrl     = "file_url"
@@ -76,6 +87,14 @@ extension Client {
         }
     }
 
+    /// Write the given file to E3DB. Intended for data from 1MB up to 5GB in size. The contents of the file are
+    /// encrypted before being uploaded.
+    ///
+    /// - Parameters:
+    ///   - type: The kind of data this record represents
+    ///   - fileUrl: The local URL for the file to upload
+    ///   - plain: A user-defined, key-value store associated with the record that remains as plaintext
+    ///   - completion: A handler to call when this operation completes to provide the file info result
     public func writeFile(type: String, fileUrl: URL, plain: PlainMeta? = nil, completion: @escaping E3dbCompletion<Meta>) {
         let clientId = config.clientId
         getAccessKey(writerId: clientId, userId: clientId, readerId: clientId, recordType: type) { result in
@@ -158,6 +177,12 @@ extension Client {
         }
     }
 
+    /// Read the file associated with the given record from the server.
+    ///
+    /// - Parameters:
+    ///   - recordId: The identifier for the `Record` to read. Record must reference a previously uploaded file.
+    ///   - destination: Local location to write the decrypted contents of the referenced file.
+    ///   - completion: A handler to call when the operation completes to provide the decrypted record `Meta`
     public func readFile(recordId: UUID, destination: URL, completion: @escaping E3dbCompletion<Meta>) {
         let readReq = ReadFileRequest(api: api, recordId: recordId)
         authedClient.performDefault(readReq) { result in

--- a/E3db/Classes/Record.swift
+++ b/E3db/Classes/Record.swift
@@ -60,6 +60,7 @@ public struct ClientMeta: Codable {
     /// associated with the document that remains as plaintext
     public let plain: PlainMeta?
 
+    /// Holds info about a file associated with this record, if any
     public let fileMeta: FileMeta?
 
     enum CodingKeys: String, CodingKey {
@@ -99,6 +100,7 @@ public struct Meta: Decodable {
     /// An identifier for the current version of the record
     public let version: String
 
+    /// Holds info about a file associated with this record, if any
     public let fileMeta: FileMeta?
 
     enum CodingKeys: String, CodingKey {

--- a/E3db/Classes/Record.swift
+++ b/E3db/Classes/Record.swift
@@ -259,6 +259,10 @@ extension Client {
         readRaw(recordId: recordId, fields: fields) { result in
             switch result {
             case .success(let record):
+                guard !record.cipherData.isEmpty else {
+                    let emptyRec = Record(meta: record.meta, data: [:])
+                    return completion(.success(emptyRec))
+                }
                 self.decryptRecord(record: record, completion: completion)
             case .failure(let err):
                 completion(Result(error: err))

--- a/E3db/Classes/Record.swift
+++ b/E3db/Classes/Record.swift
@@ -60,11 +60,14 @@ public struct ClientMeta: Codable {
     /// associated with the document that remains as plaintext
     public let plain: PlainMeta?
 
+    public let fileMeta: FileMeta?
+
     enum CodingKeys: String, CodingKey {
         case writerId = "writer_id"
         case userId   = "user_id"
         case type
         case plain
+        case fileMeta = "file_meta"
     }
 }
 
@@ -96,6 +99,8 @@ public struct Meta: Decodable {
     /// An identifier for the current version of the record
     public let version: String
 
+    public let fileMeta: FileMeta?
+
     enum CodingKeys: String, CodingKey {
         case recordId     = "record_id"
         case writerId     = "writer_id"
@@ -105,6 +110,7 @@ public struct Meta: Decodable {
         case created
         case lastModified = "last_modified"
         case version
+        case fileMeta     = "file_meta"
     }
 }
 
@@ -166,7 +172,8 @@ extension Client {
             writerId: config.clientId,
             userId: config.clientId,    // for now
             type: type,
-            plain: plain
+            plain: plain,
+            fileMeta: nil
         )
         let record = RecordRequestInfo(meta: meta, data: cipher)
 
@@ -311,7 +318,8 @@ extension Client {
                     writerId: meta.writerId,
                     userId: meta.userId,
                     type: meta.type,
-                    plain: plain
+                    plain: plain,
+                    fileMeta: nil
                 )
                 self.update(meta.recordId, version: meta.version, metaReq: metaReq, data: newData, ak: ak.rawAk, completion: completion)
             case .failure(let err):

--- a/E3db/Classes/Utils.swift
+++ b/E3db/Classes/Utils.swift
@@ -100,6 +100,7 @@ struct Api {
         case accessKeys = "access_keys"
         case search
         case policy
+        case files
     }
 
     static let defaultUrl   = "https://api.e3db.com/"

--- a/Example/E3db-Example.xcodeproj/project.pbxproj
+++ b/Example/E3db-Example.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		2C13341B20F40D500000759D /* blns-swift.json in Resources */ = {isa = PBXBuildFile; fileRef = 2C13341A20F40D500000759D /* blns-swift.json */; };
 		2C13341D20F535220000759D /* blns-node.json in Resources */ = {isa = PBXBuildFile; fileRef = 2C13341C20F535210000759D /* blns-node.json */; };
 		2C13341F20F5357D0000759D /* blns-java.json in Resources */ = {isa = PBXBuildFile; fileRef = 2C13341E20F5357D0000759D /* blns-java.json */; };
+		2C4B69A02155BF8F003650DB /* CryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4B699F2155BF8F003650DB /* CryptoTests.swift */; };
 		2C5AE665208E54F4008F52C5 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5AE65D208E54F4008F52C5 /* ViewController.swift */; };
 		2C5AE666208E54F4008F52C5 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2C5AE65E208E54F4008F52C5 /* LaunchScreen.xib */; };
 		2C5AE667208E54F4008F52C5 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2C5AE660208E54F4008F52C5 /* Main.storyboard */; };
@@ -46,6 +47,7 @@
 		2C13341A20F40D500000759D /* blns-swift.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "blns-swift.json"; sourceTree = "<group>"; };
 		2C13341C20F535210000759D /* blns-node.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "blns-node.json"; sourceTree = "<group>"; };
 		2C13341E20F5357D0000759D /* blns-java.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "blns-java.json"; sourceTree = "<group>"; };
+		2C4B699F2155BF8F003650DB /* CryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoTests.swift; sourceTree = "<group>"; };
 		2C5AE65D208E54F4008F52C5 /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		2C5AE65F208E54F4008F52C5 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		2C5AE661208E54F4008F52C5 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -136,6 +138,7 @@
 				2CAF7AEC2085B1DF0061397F /* DocumentTests.swift */,
 				2CAF7AED2085B1DF0061397F /* IntegrationTests.swift */,
 				2CAF7AEA2085B1DF0061397F /* PropertyTests.swift */,
+				2C4B699F2155BF8F003650DB /* CryptoTests.swift */,
 				2CAF7AEE2085B1E00061397F /* TestUtils.swift */,
 				2C13341A20F40D500000759D /* blns-swift.json */,
 				2C13341E20F5357D0000759D /* blns-java.json */,
@@ -426,6 +429,7 @@
 				2CAF7AF22085B1E00061397F /* DocumentTests.swift in Sources */,
 				2CAF7AF42085B1E00061397F /* TestUtils.swift in Sources */,
 				2CAF7AF02085B1E00061397F /* PropertyTests.swift in Sources */,
+				2C4B69A02155BF8F003650DB /* CryptoTests.swift in Sources */,
 				2CAF7AF32085B1E00061397F /* IntegrationTests.swift in Sources */,
 				2CAF7AF12085B1E00061397F /* Data+Base64URL.swift in Sources */,
 				2CAF7AEF2085B1E00061397F /* BenchmarkTests.swift in Sources */,

--- a/Example/Tests/CryptoTests.swift
+++ b/Example/Tests/CryptoTests.swift
@@ -1,0 +1,59 @@
+//
+//  CryptoTests.swift
+//  E3db_Tests
+//
+
+import XCTest
+@testable import E3db
+
+class CryptoTests: XCTestCase, TestUtils {
+
+    func testFileEncryptDecryptEqual() {
+        let srcUrl = FileManager.tempBinFile()
+        let data   = Data(repeatElement("testing", count: 100).joined().utf8)
+
+        do {
+            try data.write(to: srcUrl)
+            let accessKey = Crypto.generateAccessKey()!
+            let encrypted = try Crypto.encrypt(fileAt: srcUrl, ak: accessKey)
+            let decrypted = FileManager.tempBinFile()
+            try Crypto.decrypt(fileAt: encrypted, to: decrypted, ak: accessKey)
+
+            guard let input = InputStream(url: decrypted) else {
+                return XCTFail("Could not open decrypted file")
+            }
+            input.open()
+            defer {
+                input.close()
+                try! FileManager.default.removeItem(at: srcUrl)
+                try! FileManager.default.removeItem(at: encrypted)
+                try! FileManager.default.removeItem(at: decrypted)
+            }
+
+            var buffer = Data(count: data.count)
+            guard input.read(data: &buffer) != -1 else {
+                return XCTFail("Failed to read file")
+            }
+            XCTAssertEqual(buffer, data)
+        } catch {
+            return XCTFail(error.localizedDescription)
+        }
+    }
+
+    func testMD5() {
+        let srcUrl = FileManager.tempBinFile()
+        let data   = Data(repeatElement("testing", count: 10).joined().utf8)
+        defer {
+            try! FileManager.default.removeItem(at: srcUrl)
+        }
+        do {
+            try data.write(to: srcUrl)
+            let expected = "DPb7oJVFD4O0cXsAkVRltA=="
+            let actual   = try Crypto.computeInfo(ofFile: srcUrl)
+            XCTAssertEqual(expected, actual.md5)
+        } catch {
+            return XCTFail(error.localizedDescription)
+        }
+    }
+
+}

--- a/Example/Tests/CryptoTests.swift
+++ b/Example/Tests/CryptoTests.swift
@@ -17,7 +17,7 @@ class CryptoTests: XCTestCase, TestUtils {
             let accessKey = Crypto.generateAccessKey()!
             let encrypted = try Crypto.encrypt(fileAt: srcUrl, ak: accessKey)
             let decrypted = FileManager.tempBinFile()
-            try Crypto.decrypt(fileAt: encrypted, to: decrypted, ak: accessKey)
+            try Crypto.decrypt(fileAt: encrypted.url, to: decrypted, ak: accessKey)
 
             guard let input = InputStream(url: decrypted) else {
                 return XCTFail("Could not open decrypted file")
@@ -26,7 +26,7 @@ class CryptoTests: XCTestCase, TestUtils {
             defer {
                 input.close()
                 try! FileManager.default.removeItem(at: srcUrl)
-                try! FileManager.default.removeItem(at: encrypted)
+                try! FileManager.default.removeItem(at: encrypted.url)
                 try! FileManager.default.removeItem(at: decrypted)
             }
 
@@ -49,8 +49,8 @@ class CryptoTests: XCTestCase, TestUtils {
         do {
             try data.write(to: srcUrl)
             let expected = "DPb7oJVFD4O0cXsAkVRltA=="
-            let actual   = try Crypto.computeInfo(ofFile: srcUrl)
-            XCTAssertEqual(expected, actual.md5)
+            let actual   = try Crypto.md5(ofFile: srcUrl)
+            XCTAssertEqual(expected, actual)
         } catch {
             return XCTFail(error.localizedDescription)
         }

--- a/Example/Tests/IntegrationTests.swift
+++ b/Example/Tests/IntegrationTests.swift
@@ -868,7 +868,7 @@ class IntegrationTests: XCTestCase, TestUtils {
             }
         }
 
-        // shared client should now see file contents
+        // shared client should not see file contents
         asyncTest(#function + "read file failure") { (expect) in
             shareClient.readFile(recordId: meta!.recordId, destination: dstUrl) { (result) in
                 XCTAssertNil(result.value)

--- a/Example/Tests/IntegrationTests.swift
+++ b/Example/Tests/IntegrationTests.swift
@@ -672,6 +672,9 @@ class IntegrationTests: XCTestCase, TestUtils {
         guard let srcUrl = FileManager.tempBinFile() else {
             return XCTFail("Could not open file")
         }
+        defer {
+            try! FileManager.default.removeItem(at: srcUrl)
+        }
         let e3db = client()
         let data = Data(repeatElement("testing", count: 100).joined().utf8)
 
@@ -693,6 +696,10 @@ class IntegrationTests: XCTestCase, TestUtils {
         guard let srcUrl = FileManager.tempBinFile(),
               let dstUrl = FileManager.tempBinFile() else {
             return XCTFail("Could not open files")
+        }
+        defer {
+            try! FileManager.default.removeItem(at: srcUrl)
+            try! FileManager.default.removeItem(at: dstUrl)
         }
         let e3db = client()
         let data = Data(repeatElement("testing", count: 100).joined().utf8)

--- a/Example/Tests/IntegrationTests.swift
+++ b/Example/Tests/IntegrationTests.swift
@@ -827,6 +827,106 @@ class IntegrationTests: XCTestCase, TestUtils {
         let fileData = try! Data(contentsOf: dstUrl)
         XCTAssert(fileData.isEmpty, "File should have no contents")
     }
+
+    func testShareRevokeFile() {
+        let mainClient = client()
+        let (shareClient, sharedId) = clientWithId()
+        guard let srcUrl = FileManager.tempBinFile(),
+              let dstUrl = FileManager.tempBinFile() else {
+                return XCTFail("Could not open files")
+        }
+        defer {
+            try! FileManager.default.removeItem(at: srcUrl)
+            try! FileManager.default.removeItem(at: dstUrl)
+        }
+        let data = Data(repeatElement("testing", count: 100).joined().utf8)
+        let type = "test-file"
+
+        guard let _ = try? data.write(to: srcUrl) else {
+            return XCTFail("Failed to write data")
+        }
+        var meta: Meta?
+
+        // write initial file
+        asyncTest(#function + "write") { (expect) in
+            mainClient.writeFile(type: type, fileUrl: srcUrl) { (result) in
+                XCTAssertNil(result.error)
+                XCTAssertNotNil(result.value)
+                XCTAssertNotNil(result.value?.fileMeta?.fileName)
+                meta = result.value
+                expect.fulfill()
+            }
+        }
+
+        // shared client should not see records initially
+        let query = QueryParams(includeData: true, includeAllWriters: true)
+        asyncTest(#function + "read first") { (expect) in
+            shareClient.query(params: query) { (result) in
+                XCTAssertNotNil(result.value)
+                XCTAssert(result.value!.records.count == 0)
+                expect.fulfill()
+            }
+        }
+
+        // shared client should now see file contents
+        asyncTest(#function + "read file failure") { (expect) in
+            shareClient.readFile(recordId: meta!.recordId, destination: dstUrl) { (result) in
+                XCTAssertNil(result.value)
+                XCTAssertNotNil(result.error)
+                expect.fulfill()
+            }
+        }
+
+        // share record type
+        asyncTest(#function + "share") { (expect) in
+            mainClient.share(type: meta!.type, readerId: sharedId) { (result) in
+                XCTAssertNil(result.error)
+                expect.fulfill()
+            }
+        }
+
+        // shared client should now see full record
+        asyncTest(#function + "read again") { (expect) in
+            shareClient.query(params: query) { (result) in
+                XCTAssertNotNil(result.value)
+                XCTAssert(result.value!.records.count == 1)
+                XCTAssert(result.value!.records[0].meta.recordId == meta!.recordId)
+                XCTAssert(result.value!.records[0].data.isEmpty)
+                expect.fulfill()
+            }
+        }
+
+        // shared client should now see file contents
+        asyncTest(#function + "read file") { (expect) in
+            shareClient.readFile(recordId: meta!.recordId, destination: dstUrl) { (result) in
+                XCTAssertNil(result.error)
+                do {
+                    let contents = try Data(contentsOf: dstUrl)
+                    XCTAssertEqual(contents, data)
+                } catch {
+                    XCTFail(error.localizedDescription)
+                }
+                expect.fulfill()
+            }
+        }
+
+        // unshare record type
+        asyncTest(#function + "revoke") { (expect) in
+            mainClient.revoke(type: meta!.type, readerId: sharedId) { (result) in
+                XCTAssertNil(result.error)
+                expect.fulfill()
+            }
+        }
+
+        // shared client should no longer see record
+        asyncTest(#function + "read last") { (expect) in
+            shareClient.query(params: query) { (result) in
+                XCTAssertNotNil(result.value)
+                XCTAssert(result.value!.records.count == 0)
+                expect.fulfill()
+            }
+        }
+    }
 }
 
 class ValidCertIntegrationTests: XCTestCase, TestUtils, PinnedCertificate, URLSessionDelegate {

--- a/Example/Tests/PropertyTests.swift
+++ b/Example/Tests/PropertyTests.swift
@@ -16,6 +16,28 @@ extension UUID: Arbitrary {
     }
 }
 
+extension URL: Arbitrary {
+    public static var arbitrary: Gen<URL> {
+        return Gen<URL>.compose { c in
+            return URL(fileURLWithPath: c.generate())
+        }
+    }
+}
+
+extension FileMeta: Arbitrary {
+    public static var arbitrary: Gen<FileMeta> {
+        return Gen<FileMeta>.compose { c in
+            FileMeta(
+                fileUrl: c.generate(),
+                fileName: c.generate(),
+                checksum: c.generate(),
+                compression: c.generate(),
+                size: c.generate()
+            )
+        }
+    }
+}
+
 extension ClientMeta: Arbitrary {
     public static var arbitrary: Gen<ClientMeta> {
         return Gen<ClientMeta>.compose { c in
@@ -23,7 +45,8 @@ extension ClientMeta: Arbitrary {
                 writerId: c.generate(),
                 userId: c.generate(),
                 type: c.generate(),
-                plain: c.generate()
+                plain: c.generate(),
+                fileMeta: c.generate()
             )
         }
     }

--- a/README.md
+++ b/README.md
@@ -366,6 +366,96 @@ guard try e3db.verify(signed: signed, pubSigKey: config.publicSigKey)) else {
 // Document verified!
 ```
 
+#### Reading and Writing Files
+
+E3DB supports the storage of large encrypted files, using a similar interface
+for reading and writing records. The SDK will handle encrypting and uploading
+the file. Similarly, it will download and decrypt files as well.
+
+To write a file, use the `writeFile` method.
+
+```swift
+let data = Data("Hello there".utf8)
+let src  = FileManager
+    .default
+    .temporaryDirectory
+    .appendingPathComponent("source-file")
+    .appendingPathExtension("txt")
+
+guard FileManager.default.createFile(atPath: src.path, contents: data) else {
+    return print("Could not create file")
+}
+
+var recordId: UUID?
+e3db.writeFile(type: type, fileUrl: src) { result in
+    switch result {
+    // The operation was successful, here's the `Meta` instance.
+    case .success(let meta):
+        recordId = meta.recordId
+    case .failure(let error):
+        print("An error occurred attempting to write file: \(error)")
+    }
+}
+```
+
+Similarly, to read a file, use the `readFile` method. The `File` argument should
+be the destination that the plaintext file will be written to. Continuing the
+example above, you could read the file written as follows:
+
+```swift
+let dest = FileManager
+    .default
+    .temporaryDirectory
+    .appendingPathComponent("destination-file")
+    .appendingPathExtension("txt")
+
+guard FileManager.default.createFile(atPath: dest.path, contents: nil) else {
+    return print("Could not create file")
+}
+
+e3db.readFile(recordId: recordId, destination: dest) { result in
+    switch result {
+    case .success:
+        print("File was downloaded, decrypted, and saved to \(dest.path)!")
+    case .failure(let error):
+        print("An error occurred attempting to read file: \(error)")
+    }
+}
+```
+
+##### Storage Requirements
+
+When uploading a file, the SDK expects to be able to (temporarily) store an
+encrypted version of the plaintext file in the system's temporary directory.
+Once the upload finishes (with or without error), the temporary file will be
+deleted.
+
+When downloading a file, you must provide a location to which the file can be
+written. The SDK will save the encrypted file to storage, again in the system's
+temporary directory. The SDK will then decrypt the encrypted file writing the
+plaintext to the destination file.
+
+In both cases, uploading and downloading, the SDK expects at least twice as much
+free storage as the size of the plaintext or encrypted file.
+
+##### Query Results
+
+Query results may include file records (uploaded via the `writeFile` method).
+A large file (vs. just a record) is indicated when the `fileMeta` property on
+the `Meta` instance is not `nil`. The contents of the file will _not_ be
+included in query results, even if the `includeData` parameter of the
+`QueryParams` is `true`. Use the `readFile` method to retrieve the contents of
+the file.
+
+Note that the `data` property will be empty when the record refers to a file.
+
+##### Reading Records
+
+If the `read(recordId:)` method is used to read a record that refers to a file,
+the result will be the same as when a query result contains a file record.
+Namely, the record's `data` property will be empty, and the `fileMeta` property
+of the returned `meta` will be non-`nil`.
+
 ### Certificate Pinning
 
 If desired, E3DB Clients can be provided with a `URLSession` instance. This can


### PR DESCRIPTION
Implements Read / Write for files using the sodium streaming interface.
- Computes MD5 during encryption so that it only requires one pass through the file
- Uses `FileHandler` interface for working with the file system
- Adds guards for `CommonCrypto` importing for reasons described below

The additions require Apple's `CommonCrypto` library as a module map following the instructions for framework projects [here](https://spin.atomicobject.com/2015/02/23/c-libraries-swift/). This will require users of this SDK to follow the same instructions for their own apps when integrating the SDK. This will be unnecessary when upgrading to XCode 10 / Swift 4.2, but currently [swift-sodium is not updated](https://github.com/jedisct1/swift-sodium/issues/155) for that yet. 

Additional tests and documentation to follow, just wanted to get a PR in for early review.