### PR TITLE
Use local values for client info if requesting own

### DIFF
--- a/E3db/Classes/Client.swift
+++ b/E3db/Classes/Client.swift
@@ -105,13 +105,11 @@ struct ClientInfo: Decodable {
     let clientId: UUID
     let publicKey: ClientKey
     let signingKey: SigningKey?
-    let validated: Bool
 
     enum CodingKeys: String, CodingKey {
         case clientId   = "client_id"
         case publicKey  = "public_key"
         case signingKey = "signing_key"
-        case validated
     }
 }
 
@@ -128,7 +126,14 @@ extension Client {
     }
 
     func getClientInfo(clientId: UUID? = nil, completion: @escaping E3dbCompletion<ClientInfo>) {
-        let req = ClientInfoRequest(api: api, clientId: clientId ?? config.clientId)
+        guard let otherId = clientId,
+              otherId != config.clientId else {
+            let pubK = ClientKey(curve25519: config.publicKey)
+            let sigK = SigningKey(ed25519: config.publicSigKey)
+            let info = ClientInfo(clientId: config.clientId, publicKey: pubK, signingKey: sigK)
+            return completion(.success(info))
+        }
+        let req = ClientInfoRequest(api: api, clientId: otherId)
         authedClient.performDefault(req, completion: completion)
     }
 }


### PR DESCRIPTION
This saves a round-trip since the values are already in the config instance. Even though this removes a value from the `ClientInfo` struct, this is not a breaking change because it's an internal-only structure.