### PR TITLE
Update swift-sodium dependency to 0.7

### DIFF
--- a/E3db.podspec
+++ b/E3db.podspec
@@ -19,7 +19,7 @@ E3DB provides a familiar JSON-based NoSQL-style API for reading, writing, and qu
 
   s.subspec 'Core' do |core|
     core.dependency 'Swish', '~> 3.0'
-    core.dependency 'Sodium', '~> 0.6'
+    core.dependency 'Sodium', '~> 0.7'
     core.dependency 'Valet', '~> 3.1'
     core.dependency 'Heimdallr', '~> 3.6'
   end

--- a/E3db/Classes/Extensions.swift
+++ b/E3db/Classes/Extensions.swift
@@ -132,24 +132,32 @@ extension APIClient {
     }
 }
 
-extension Data {
+extension Array where Element == UInt8 {
 
     public init?(base64UrlEncoded string: String) {
-        guard let data = try? Crypto.base64UrlDecoded(string: string) else {
+        guard let bytes = try? Crypto.base64UrlDecoded(string: string) else {
             return nil
         }
-        self = data
+        self = bytes
     }
 
     public func base64UrlEncodedString() -> String? {
-        return try? Crypto.base64UrlEncoded(data: self)
+        return try? Crypto.base64UrlEncoded(bytes: self)
     }
+
+}
+
+extension Data {
 
     #if canImport(CommonCrypto)
     func updateMD5(context: UnsafeMutablePointer<CC_MD5_CTX>) {
         _ = withUnsafeBytes { CC_MD5_Update(context, $0, CC_LONG(count)) }
     }
     #endif
+
+    var bytes: [UInt8] {
+        return [UInt8](self)
+    }
 }
 
 extension FileManager {

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - E3db (1.4.0):
-    - E3db/Core (= 1.4.0)
-  - E3db/Core (1.4.0):
+  - E3db (3.0.0):
+    - E3db/Core (= 3.0.0)
+  - E3db/Core (3.0.0):
     - Heimdallr (~> 3.6)
-    - Sodium (~> 0.6)
+    - Sodium (~> 0.7)
     - Swish (~> 3.0)
     - Valet (~> 3.1)
   - Heimdallr (3.6.1):
@@ -12,11 +12,11 @@ PODS:
     - Result (~> 3.0)
   - ResponseDetective (1.2.4)
   - Result (3.2.4)
-  - Sodium (0.6)
+  - Sodium (0.7.0)
   - SwiftCheck (0.10.0)
   - Swish (3.0.0):
     - Result (~> 3.1)
-  - Valet (3.1.3)
+  - Valet (3.2.2)
 
 DEPENDENCIES:
   - E3db (from `../`)
@@ -38,14 +38,14 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  E3db: c7f1c885bdc810b05a9115782d925a0b7c73d3c0
+  E3db: 49672ac7be551985814b0404cd26859f22146631
   Heimdallr: d2a8b1dc3ecc7ad249c9ffd20c990e2248fcd599
   ResponseDetective: 710b1b41903382460592a75a480440661bcadfa6
   Result: d2d07204ce72856f1fd9130bbe42c35a7b0fea10
-  Sodium: bf524b0a3d5ad6870dcf343205cca7e659c15ad5
+  Sodium: c5510cc6f5e1b27858e5f260b5cac80d4a3f9379
   SwiftCheck: 8a3c3638941467bc142d625f374a8409dd262ae8
   Swish: 68621dbf8f0c0ed1660cb620f3ce8d5218f6bf38
-  Valet: fae4295525b1f13048147d30a38f66d266af9338
+  Valet: 0babf5737029004185a7a009c1135f0c073011d1
 
 PODFILE CHECKSUM: 64794b8cc17b0d0d47676843076f1d7caca89541
 

--- a/Example/Tests/BenchmarkTests.swift
+++ b/Example/Tests/BenchmarkTests.swift
@@ -76,7 +76,7 @@ class BenchmarkTests: XCTestCase, TestUtils {
     // 1-byte-per-character sizes for easier measurement
     static func randomRecordData(numBytes: Int) -> RecordData {
         let data = sodium.randomBytes.buf(length: numBytes)
-            .map { $0.asciiMasked() }
+            .map { Data(bytes: $0.asciiMasked()) }
             .flatMap { String(data: $0, encoding: .ascii) }
             .map { RecordData(cleartext: ["": $0]) }
         return data!

--- a/Example/Tests/PropertyTests.swift
+++ b/Example/Tests/PropertyTests.swift
@@ -80,7 +80,7 @@ class PropertyTests: XCTestCase, TestUtils {
     
     func testBase64urlEncoding() {
         property("Base64url encoding for sodium should match manual") <- forAll { (data: Data) in
-            let sodiumEncoded = try? Crypto.base64UrlEncoded(data: data)
+            let sodiumEncoded = try? Crypto.base64UrlEncoded(bytes: data.bytes)
             let manualEncoded = data.base64URLEncodedString()
             return sodiumEncoded != nil && sodiumEncoded! == manualEncoded
         }
@@ -90,7 +90,7 @@ class PropertyTests: XCTestCase, TestUtils {
         property("Base64url decoding for sodium should match manual") <- forAll { (encoded: Base64UrlEncodedString) in
             let sodiumDecoded = try? Crypto.base64UrlDecoded(string: encoded.value)
             let manualDecoded = Data(base64URLEncoded: encoded.value)
-            return sodiumDecoded != nil && manualDecoded != nil && sodiumDecoded! == manualDecoded!
+            return sodiumDecoded != nil && manualDecoded != nil && Data(bytes: sodiumDecoded!) == manualDecoded!
         }
     }
 

--- a/Example/Tests/TestUtils.swift
+++ b/Example/Tests/TestUtils.swift
@@ -291,9 +291,8 @@ extension SignedDocument: MemoryReportable {
     }
 }
 
-extension Data {
-    func asciiMasked() -> Data {
-        let maskedBytes = [UInt8](self).map { $0 & 127 }
-        return Data(bytes: maskedBytes)
+extension Array where Element == UInt8 {
+    func asciiMasked() -> [UInt8] {
+        return map { $0 & 127 }
     }
 }


### PR DESCRIPTION
I noticed [swift-sodium](https://github.com/jedisct1/swift-sodium/releases) got a new release! This should help folks that had problems with XCode 10. 
- Major changes include working with `Bytes` as typealias for
  `[UInt8]` aka `Array<UInt8>`, instead of `Data`
- Some functions, such as key generation, no longer return `Optional`s
- All tests pass, including recent files work