### PR TITLE
[WASH-937] Adding realm info awareness for identity register and login

### DIFF
--- a/E3db/Classes/Config.swift
+++ b/E3db/Classes/Config.swift
@@ -10,7 +10,7 @@ import Valet
 public struct Config: Codable {
 
     /// The name for this client
-    public let clientName: String
+    public let clientName: String?
 
     /// The client identifier
     public let clientId: UUID
@@ -51,7 +51,7 @@ public struct Config: Codable {
     ///   - privateKey: The client's secret key
     ///   - baseApiUrl: The base URL for the E3DB service
     public init(
-        clientName: String,
+        clientName: String?,
         clientId: UUID,
         apiKeyId: String,
         apiSecret: String,
@@ -61,7 +61,7 @@ public struct Config: Codable {
         publicSigKey: String,
         privateSigKey: String
     ) {
-        self.clientName = clientName
+        self.clientName = clientName ?? ""
         self.clientId = clientId
         self.apiKeyId = apiKeyId
         self.apiSecret = apiSecret
@@ -277,11 +277,12 @@ extension Config {
 }
 
 public class IdentityConfig: Codable {
-    internal init(realmName: String, appName: String, apiUrl: String = Api.defaultUrl, username: String, userId: Int? = nil, brokerTargetUrl: String, firstName: String? = nil, lastName: String? = nil, storageConfig: Config) {
+    internal init(realmName: String, realmDomain: String?, appName: String, apiUrl: String = Api.defaultUrl, username: String?, userId: Int? = nil, brokerTargetUrl: String, firstName: String? = nil, lastName: String? = nil, storageConfig: Config) {
         self.realmName = realmName
+        self.realmDomain = realmDomain ?? ""
         self.appName = appName
         self.apiUrl = apiUrl
-        self.username = username
+        self.username = username ?? ""
         self.storageConfig = storageConfig
 
         self.firstName = firstName
@@ -304,6 +305,7 @@ public class IdentityConfig: Codable {
                                    privateSigKey: noteData.storage.privateSigKey)
 
         self.init(realmName:noteData.config.realmName,
+                  realmDomain:noteData.config.realmDomain,
                   appName: noteData.config.appName,
                   apiUrl: noteData.config.apiUrl,
                   username: noteData.config.username,
@@ -314,6 +316,7 @@ public class IdentityConfig: Codable {
 
     // required to initialize and login to an identity client
     public let realmName: String
+    public let realmDomain: String
     public let appName: String
     public let apiUrl: String
     public let username: String

--- a/E3db/Classes/IdentityAPI.swift
+++ b/E3db/Classes/IdentityAPI.swift
@@ -122,17 +122,31 @@ public struct NoteCredentials {
     let signingKeyPair: SigningKeyPair
 }
 
+public struct PublicRealmInfo: Codable {
+    let name: String
+    let brokerId: UUID?
+    let domain: String
+    
+    enum CodingKeys: String, CodingKey {
+        case name
+        case brokerId = "broker_id"
+        case domain
+    }
+}
+
 public struct PasswordNoteData: Codable {
     struct idConfig: Codable {
         let realmName: String
+        let realmDomain: String?
         let appName: String
         let apiUrl: String
-        let username: String
+        let username: String?
         let brokerTargetUrl: String
         let userId: Int?
 
         enum CodingKeys: String, CodingKey {
             case realmName = "realm_name"
+            case realmDomain = "realm_domain"
             case appName = "app_name"
             case apiUrl = "api_url"
             case username
@@ -170,6 +184,7 @@ public struct PasswordNoteData: Codable {
 
     init(identity: IdentityConfig, store: Config) {
         config = idConfig(realmName: identity.realmName,
+                          realmDomain: identity.realmDomain,
                           appName: identity.appName,
                           apiUrl: identity.apiUrl,
                           username: identity.username,


### PR DESCRIPTION
- Adds a new struct which contains the public realm info
- Calls realm info endpoint during identity register and login
- Updates identity and storage config structs to handle notes with slightly different data