### PR TITLE
[WASH1110] Remove empty symlink

### DIFF
--- a/_Pods.xcodeproj
+++ b/_Pods.xcodeproj
@@ -1,1 +1,0 @@
-Example/Pods/Pods.xcodeproj


### PR DESCRIPTION
This symlink was made when this repo was first created, but points to a file & folder that aren't committed. This caused an error when using gitpacker.
I've removed the symlink (which is not used anywhere in this repo) & verified that the build is still successful & tests still pass.